### PR TITLE
update

### DIFF
--- a/content/blog/ecosia-preservateur-decologie.mdx
+++ b/content/blog/ecosia-preservateur-decologie.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Ecosia et ReforestAction : agir pour le climat grâce au numérique"
+title: "Ecosia et Reforest'Action : agir pour le climat grâce au numérique"
 date: "2022-06-23"
 author: "Louis-Arnaud Catoire"
 category: "Green IT"
-excerpt: "Dans un monde où le changement climatique est une préoccupation majeure, des initiatives comme Ecosia et ReforestAction jouent un rôle crucial."
+excerpt: "Dans un monde où le changement climatique est une préoccupation majeure, des initiatives comme Ecosia et Reforest'Action jouent un rôle crucial."
 image: "/images/blog/ecosia.webp"
 proficiencyLevel: "Beginner"
 updatedAt: "2026-01-13"
 ---
 
-Dans un monde où le changement climatique est une préoccupation majeure, des initiatives innovantes comme Ecosia et ReforestAction jouent un rôle crucial. Ces deux organisations se consacrent à la reforestation, apportant des solutions concrètes pour combattre la déforestation et ses effets dévastateurs sur notre planète. Alors que nos usages numériques ne cessent de croître, il est réconfortant de constater que certaines entreprises transforment ces usages en levier positif pour l'environnement.
+Dans un monde où le changement climatique est une préoccupation majeure, des initiatives innovantes comme Ecosia et Reforest'Action jouent un rôle crucial. Ces deux organisations se consacrent à la reforestation, apportant des solutions concrètes pour combattre la déforestation et ses effets dévastateurs sur notre planète. Alors que nos usages numériques ne cessent de croître, il est réconfortant de constater que certaines entreprises transforment ces usages en levier positif pour l'environnement.
 
 ## Ecosia : un moteur de recherche vert qui finance la reforestation
 
@@ -47,25 +47,25 @@ Ce qui distingue Ecosia de ses concurrents, c'est avant tout son échelle et sa 
 
 Efficience IT a choisi d'opter pour Ecosia ; pour en savoir plus, rendez-vous sur notre [page Green IT](/green-it).
 
-## ReforestAction : engagée dans la reforestation contre le changement climatique
+## Reforest'Action : engagée dans la reforestation contre le changement climatique
 
-[ReforestAction](https://www.reforestaction.com/) est une organisation française fondée en 2010 par Stéphane Hallaire. Son objectif est de planter des arbres dans des zones dégradées pour lutter contre la déforestation et le changement climatique. Depuis sa création, ReforestAction a planté plus de 11 millions d'arbres dans le monde entier, en collaboration avec des partenaires locaux.
+[Reforest'Action](https://www.reforestaction.com/) est une organisation française fondée en 2010 par Stéphane Hallaire. Son objectif est de planter des arbres dans des zones dégradées pour lutter contre la déforestation et le changement climatique. Depuis sa création, Reforest'Action a planté plus de 11 millions d'arbres dans le monde entier, en collaboration avec des partenaires locaux.
 
 ### Une approche à haute valeur environnementale
 
-L'approche de ReforestAction est basée sur une stratégie de plantation d'arbres à haute valeur environnementale et économique, qui bénéficie aux populations locales et à la biodiversité. L'organisation travaille en étroite collaboration avec les communautés locales pour sensibiliser les habitants aux enjeux de la déforestation et pour les impliquer dans les projets de reforestation. Chaque projet est conçu pour avoir un impact positif durable, en renforçant les écosystèmes et en soutenant les moyens de subsistance des communautés locales.
+L'approche de Reforest'Action est basée sur une stratégie de plantation d'arbres à haute valeur environnementale et économique, qui bénéficie aux populations locales et à la biodiversité. L'organisation travaille en étroite collaboration avec les communautés locales pour sensibiliser les habitants aux enjeux de la déforestation et pour les impliquer dans les projets de reforestation. Chaque projet est conçu pour avoir un impact positif durable, en renforçant les écosystèmes et en soutenant les moyens de subsistance des communautés locales.
 
-Les projets de ReforestAction couvrent des écosystèmes variés : forêts tropicales, mangroves, agroforesterie et restauration de forêts tempérées. Cette diversité rappelle l'importance de concevoir des sites web [conformes aux normes RGAA](/article/normes-rgaa-les-cles-dune-experience-utilisateur-reussie-pour-tous) pour que l'information environnementale reste accessible à tous les publics. Elle permet de répondre à des problématiques environnementales différentes selon les régions du monde.
+Les projets de Reforest'Action couvrent des écosystèmes variés : forêts tropicales, mangroves, agroforesterie et restauration de forêts tempérées. Cette diversité rappelle l'importance de concevoir des sites web [conformes aux normes RGAA](/article/normes-rgaa-les-cles-dune-experience-utilisateur-reussie-pour-tous) pour que l'information environnementale reste accessible à tous les publics. Elle permet de répondre à des problématiques environnementales différentes selon les régions du monde.
 
 ### Un modèle de parrainage accessible à tous
 
-ReforestAction propose différentes formules de parrainage d'arbres pour les entreprises comme pour les particuliers, qui permettent à chacun de soutenir la plantation d'arbres dans des zones en difficulté. Les parrainages peuvent être réalisés en ligne, et chaque parrain reçoit des informations détaillées sur le projet qu'il a financé, ainsi que des nouvelles régulières sur l'évolution des plantations. Cette transparence et cette connexion directe avec les projets rendent le parrainage encore plus significatif.
+Reforest'Action propose différentes formules de parrainage d'arbres pour les entreprises comme pour les particuliers, qui permettent à chacun de soutenir la plantation d'arbres dans des zones en difficulté. Les parrainages peuvent être réalisés en ligne, et chaque parrain reçoit des informations détaillées sur le projet qu'il a financé, ainsi que des nouvelles régulières sur l'évolution des plantations. Cette transparence et cette connexion directe avec les projets rendent le parrainage encore plus significatif.
 
-Pour les entreprises, ReforestAction propose des programmes de compensation carbone qui permettent d'intégrer la reforestation dans une stratégie RSE globale. Ces programmes s'accompagnent d'outils de communication pour valoriser l'engagement environnemental auprès des clients et des collaborateurs.
+Pour les entreprises, Reforest'Action propose des programmes de compensation carbone qui permettent d'intégrer la reforestation dans une stratégie RSE globale. Ces programmes s'accompagnent d'outils de communication pour valoriser l'engagement environnemental auprès des clients et des collaborateurs.
 
 ## Pour finir
 
-Ecosia et ReforestAction sont deux organisations qui se sont engagées dans la lutte contre le changement climatique en plantant des arbres dans des zones en difficulté. Ecosia finance la plantation d'arbres à travers son moteur de recherche écolo, tandis que ReforestAction se concentre sur la reforestation en collaboration avec les communautés locales. Ensemble, ces deux initiatives illustrent comment le numérique et l'engagement citoyen peuvent converger pour produire un impact environnemental tangible.
+Ecosia et Reforest'Action sont deux organisations qui se sont engagées dans la lutte contre le changement climatique en plantant des arbres dans des zones en difficulté. Ecosia finance la plantation d'arbres à travers son moteur de recherche écolo, tandis que Reforest'Action se concentre sur la reforestation en collaboration avec les communautés locales. Ensemble, ces deux initiatives illustrent comment le numérique et l'engagement citoyen peuvent converger pour produire un impact environnemental tangible.
 
 Pour les entreprises tech, cette démarche s'inscrit dans une réflexion plus large sur la [visibilité responsable dans les moteurs IA](/article/geo-rendre-votre-application-symfony-visible-dans-les-moteurs-ia). Adopter Ecosia comme moteur de recherche par défaut est sans doute l'un des gestes les plus simples que chacun puisse faire pour contribuer à la reforestation mondiale. Cela ne coûte rien, ne change quasiment pas les habitudes de navigation et permet de transformer chaque recherche en ligne en un acte positif pour la planète.
 

--- a/data/greenIt.ts
+++ b/data/greenIt.ts
@@ -44,5 +44,5 @@ export const greenPractices = [
   "Zéro papier dans nos bureaux",
   "Éco-conception logicielle : travailler avec Symfony permet de partir d'une version minimaliste et de n'ajouter que les packages strictement nécessaires",
   "Sites allégés, plus performants et plus respectueux de l'environnement",
-  "Compensation écologique à 100 % de nos journées travaillées via ReforestAction",
+  "Compensation écologique à 100 % de nos journées travaillées via Reforest'Action",
 ];

--- a/data/testimonials.ts
+++ b/data/testimonials.ts
@@ -11,7 +11,7 @@ export const testimonials: Testimonial[] = [
   {
     name: "Claire Trochu",
     role: "Chef de projet",
-    company: "Cartercash",
+    company: "Carter Cash",
     quote:
       "Bonne équipe à l'écoute des besoins clients. Développeurs sérieux et impliqués.",
   },

--- a/src/app/agence-symfony-lille/page.tsx
+++ b/src/app/agence-symfony-lille/page.tsx
@@ -64,7 +64,7 @@ const faqItems = [
   {
     title: "Pourquoi choisir une agence Symfony basée à Lille ?",
     content:
-      "Lille est le 3e pôle tech de France, avec un écosystème PHP actif porté par l'AFUP Hauts-de-France. En choisissant une agence locale, vous bénéficiez de la proximité pour les réunions en présentiel, d'une connaissance directe du tissu économique régional et d'une réactivité que le travail à distance seul ne peut pas offrir.",
+      "Lille est la 3e ville tech de France, avec un écosystème PHP actif porté par l'AFUP Hauts-de-France. En choisissant une agence locale, vous bénéficiez de la proximité pour les réunions en présentiel, d'une connaissance directe du tissu économique régional et d'une réactivité que le travail à distance seul ne peut pas offrir.",
   },
   {
     title: "Peut-on se rencontrer dans vos locaux à Lille ?",

--- a/src/app/developpement-web-sur-mesure/page.tsx
+++ b/src/app/developpement-web-sur-mesure/page.tsx
@@ -471,7 +471,7 @@ export default function DeveloppementWeb() {
                 SYMFONY
               </p>
               <h2 className="mt-4 font-display text-3xl font-bold text-dark md:text-4xl">
-                Des Techs passionné(e)s
+                Une équipe passionnée
               </h2>
               <p className="mt-4 text-lg text-gray">
                 Chez Efficience IT, nous ne livrons pas simplement du code :

--- a/src/app/pourquoi-efficience-it/page.tsx
+++ b/src/app/pourquoi-efficience-it/page.tsx
@@ -280,7 +280,7 @@ export default function PourquoiEfficienceIt() {
                     Années d&apos;expérience
                   </h3>
                   <p className="mt-2 text-gray">
-                    Une expertise forgée depuis 2014 sur des projets{" "}
+                    Une expertise forgée sur des projets{" "}
                     <Link
                       href="/developpement-php"
                       className="text-primary hover:underline"

--- a/src/components/sections/AboutPreview.tsx
+++ b/src/components/sections/AboutPreview.tsx
@@ -16,7 +16,7 @@ export default function AboutPreview() {
               Nous transformons vos idées en solutions digitales rentables.
             </h2>
             <p className="mt-2 font-display text-xl font-semibold text-dark">
-              Des Techs passionné(e)s
+              Une équipe passionnée
             </p>
             <p className="mt-4 text-lg text-gray">
               Chez Efficience IT, nous ne livrons pas simplement du code : nous

--- a/src/components/sections/ExpertiseCards.tsx
+++ b/src/components/sections/ExpertiseCards.tsx
@@ -5,7 +5,7 @@ import Button from "@/components/ui/Button";
 
 const expertises = [
   {
-    title: "Développement Web Sur-Mesure",
+    title: "Développement web sur mesure",
     intro:
       "Chaque organisation a ses propres défis, c'est pourquoi nous développons des solutions qui :",
     items: [


### PR DESCRIPTION
- "depuis 2014" supprimé sur /pourquoi (entreprise créée en 2018)
- "Cartercash" → "Carter Cash" (testimonials)
- "3e pôle tech" → "3e ville tech" (Lille, alignement intra-page)
- "Développement Web Sur-Mesure" → "Développement web sur mesure"
- "Des Techs passionné(e)s" → "Une équipe passionnée" (2 fichiers)
- "ReforestAction" → "Reforest'Action" (article + greenIt.ts)