### PR TITLE
refacto

### DIFF
--- a/src/components/layout/DesktopNav.tsx
+++ b/src/components/layout/DesktopNav.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ReactNode, useCallback, useRef, useState } from "react";
+import Link from "next/link";
+import { NavItem, isDropdown } from "@/types/navigation";
+import DropdownNav from "./DropdownNav";
+
+interface DesktopNavProps {
+  items: NavItem[];
+  children?: ReactNode;
+}
+
+export default function DesktopNav({ items, children }: DesktopNavProps) {
+  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const openDropdown = useCallback((label: string) => {
+    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    setActiveDropdown(label);
+  }, []);
+
+  const closeDropdown = useCallback(() => {
+    setActiveDropdown(null);
+  }, []);
+
+  const delayedClose = useCallback(() => {
+    closeTimeoutRef.current = setTimeout(closeDropdown, 100);
+  }, [closeDropdown]);
+
+  return (
+    <nav
+      className="hidden items-center gap-1 lg:flex"
+      aria-label="Navigation principale"
+    >
+      {items.map((item) =>
+        isDropdown(item) ? (
+          <DropdownNav
+            key={item.label}
+            item={item}
+            isOpen={activeDropdown === item.label}
+            onOpen={() => openDropdown(item.label)}
+            onClose={closeDropdown}
+            onDelayedClose={delayedClose}
+          />
+        ) : (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="px-3 py-2 font-medium text-dark transition-colors hover:text-primary"
+            onMouseEnter={closeDropdown}
+          >
+            {item.label}
+          </Link>
+        ),
+      )}
+      {children}
+    </nav>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,31 +1,11 @@
-"use client";
-
-import { useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { mainNav } from "@/../data/navigation";
-import { isDropdown } from "@/types/navigation";
-import DropdownNav from "./DropdownNav";
+import DesktopNav from "./DesktopNav";
 import MobileMenu from "./MobileMenu";
 import HeaderCtas from "./HeaderCtas";
 
 export default function Header() {
-  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
-  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
-
-  const openDropdown = useCallback((label: string) => {
-    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
-    setActiveDropdown(label);
-  }, []);
-
-  const closeDropdown = useCallback(() => {
-    setActiveDropdown(null);
-  }, []);
-
-  const delayedClose = useCallback(() => {
-    closeTimeoutRef.current = setTimeout(closeDropdown, 100);
-  }, [closeDropdown]);
-
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-white">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
@@ -40,30 +20,9 @@ export default function Header() {
           />
         </Link>
 
-        <nav className="hidden items-center gap-1 lg:flex" aria-label="Navigation principale">
-          {mainNav.map((item) =>
-            isDropdown(item) ? (
-              <DropdownNav
-                key={item.label}
-                item={item}
-                isOpen={activeDropdown === item.label}
-                onOpen={() => openDropdown(item.label)}
-                onClose={closeDropdown}
-                onDelayedClose={delayedClose}
-              />
-            ) : (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="px-3 py-2 font-medium text-dark transition-colors hover:text-primary"
-                onMouseEnter={closeDropdown}
-              >
-                {item.label}
-              </Link>
-            ),
-          )}
+        <DesktopNav items={mainNav}>
           <HeaderCtas />
-        </nav>
+        </DesktopNav>
 
         <MobileMenu items={mainNav} />
       </div>

--- a/src/components/layout/HeaderCtas.tsx
+++ b/src/components/layout/HeaderCtas.tsx
@@ -1,31 +1,50 @@
-"use client";
-
-import Link from "next/link";
-import { trackEvent } from "@/lib/tracking";
+import TrackedHeaderLink from "./TrackedHeaderLink";
 
 export default function HeaderCtas() {
   return (
     <div className="ml-4 flex items-center gap-2">
-      <Link
+      <TrackedHeaderLink
         href="/audit-symfony-gratuit"
         className="group inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-dark shadow-sm transition-all duration-200 hover:border-primary/30 hover:shadow-md"
-        onClick={() => trackEvent("cta_click", { cta_location: "header_desktop", cta_text: "Audit gratuit" })}
+        location="header_desktop"
+        text="Audit gratuit"
       >
-        <svg className="h-4 w-4 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+        <svg
+          className="h-4 w-4 text-primary"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+          />
         </svg>
         Audit gratuit
-      </Link>
-      <Link
+      </TrackedHeaderLink>
+      <TrackedHeaderLink
         href="/contact"
         className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-all duration-200 hover:bg-primary-dark hover:shadow-md"
-        onClick={() => trackEvent("cta_click", { cta_location: "header_desktop", cta_text: "Contact" })}
+        location="header_desktop"
+        text="Contact"
       >
         Nous contacter
-        <svg className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+        <svg
+          className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+          />
         </svg>
-      </Link>
+      </TrackedHeaderLink>
     </div>
   );
 }

--- a/src/components/layout/TrackedHeaderLink.tsx
+++ b/src/components/layout/TrackedHeaderLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ReactNode } from "react";
+import Link from "next/link";
+import { trackEvent } from "@/lib/tracking";
+
+interface TrackedHeaderLinkProps {
+  href: string;
+  className?: string;
+  location: string;
+  text: string;
+  children: ReactNode;
+}
+
+export default function TrackedHeaderLink({
+  href,
+  className,
+  location,
+  text,
+  children,
+}: TrackedHeaderLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      onClick={() => trackEvent("cta_click", { cta_location: location, cta_text: text })}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,8 +1,5 @@
-"use client";
-
 import Container from "@/components/ui/Container";
-import Button from "@/components/ui/Button";
-import { trackEvent } from "@/lib/tracking";
+import TrackedCtaButton from "./TrackedCtaButton";
 
 export default function CallToAction() {
   return (
@@ -17,22 +14,24 @@ export default function CallToAction() {
           accompagner au mieux sur vos projets !
         </p>
         <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Button
+          <TrackedCtaButton
             href="/audit-symfony-gratuit"
             variant="white"
             size="lg"
-            onClick={() => trackEvent("cta_click", { cta_location: "footer_cta", cta_text: "Audit gratuit 30 min" })}
+            location="footer_cta"
+            text="Audit gratuit 30 min"
           >
             Audit gratuit 30 min
-          </Button>
-          <Button
+          </TrackedCtaButton>
+          <TrackedCtaButton
             href="/contact"
             variant="outline-white"
             size="lg"
-            onClick={() => trackEvent("cta_click", { cta_location: "footer_cta", cta_text: "Contactez-nous" })}
+            location="footer_cta"
+            text="Contactez-nous"
           >
             Contactez-nous
-          </Button>
+          </TrackedCtaButton>
         </div>
       </Container>
     </section>

--- a/src/components/sections/TrackedCtaButton.tsx
+++ b/src/components/sections/TrackedCtaButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ReactNode } from "react";
+import Button from "@/components/ui/Button";
+import { trackEvent } from "@/lib/tracking";
+
+type ButtonVariant = "primary" | "outline" | "outline-white" | "white" | "ghost";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface TrackedCtaButtonProps {
+  href: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+  location: string;
+  text: string;
+  children: ReactNode;
+}
+
+export default function TrackedCtaButton({
+  href,
+  variant,
+  size,
+  className,
+  location,
+  text,
+  children,
+}: TrackedCtaButtonProps) {
+  return (
+    <Button
+      href={href}
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={() => trackEvent("cta_click", { cta_location: location, cta_text: text })}
+    >
+      {children}
+    </Button>
+  );
+}


### PR DESCRIPTION
- Extraction des îlots client minimaux : `TrackedCtaButton`, `TrackedHeaderLink`, `DesktopNav`
- `CallToAction`, `HeaderCtas`, `Header` deviennent Server Components
- Réduction du bundle JS (markup statique sorti du bundle client)
- Tests inchangés : 12/12 passent