### PR TITLE
set on top ClientLogos homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,6 +56,9 @@ export default function Home() {
     <main>
       <Hero />
       <FadeIn>
+        <ClientLogos />
+      </FadeIn>
+      <FadeIn>
         <ExpertiseCards />
       </FadeIn>
       <FadeIn>
@@ -116,9 +119,6 @@ export default function Home() {
             </div>
           </Container>
         </section>
-      </FadeIn>
-      <FadeIn>
-        <ClientLogos />
       </FadeIn>
       <FadeIn>
         <section className="py-16">

--- a/src/components/sections/ClientLogos.tsx
+++ b/src/components/sections/ClientLogos.tsx
@@ -6,28 +6,50 @@ import { clients } from "@/../data/clients";
 
 export default function ClientLogos() {
   return (
-    <section className="bg-light-gray py-16 md:py-24">
+    <section className="bg-light-gray py-8 md:py-24">
       <Container>
-        <SectionTitle subtitle="Ils nous font confiance">
-          Nos clients
-        </SectionTitle>
-        <div className="grid grid-cols-2 items-center gap-8 md:grid-cols-3 lg:grid-cols-6">
+        <div className="md:hidden">
+          <SectionTitle subtitle="Ils nous font confiance">
+            Nos clients
+          </SectionTitle>
+        </div>
+
+        <div className="flex items-center gap-6 overflow-x-auto md:hidden">
           {clients.map((client) => (
-            <div key={client.name} className="flex items-center justify-center">
+            <div key={client.name} className="flex shrink-0 items-center justify-center">
               <Image
                 src={client.logo}
                 alt={client.name}
                 width={200}
                 height={120}
-                className="h-24 w-auto object-contain opacity-70 grayscale transition-all hover:opacity-100 hover:grayscale-0"
+                className="h-14 w-auto object-contain opacity-70 grayscale"
               />
             </div>
           ))}
         </div>
-        <div className="mt-10 text-center">
-          <Button href="/nos-references" variant="primary" size="lg">
-            Nos projets
-          </Button>
+
+        <div className="hidden md:block">
+          <SectionTitle subtitle="Ils nous font confiance">
+            Nos clients
+          </SectionTitle>
+          <div className="grid grid-cols-2 items-center gap-8 md:grid-cols-3 lg:grid-cols-6">
+            {clients.map((client) => (
+              <div key={client.name} className="flex items-center justify-center">
+                <Image
+                  src={client.logo}
+                  alt={client.name}
+                  width={200}
+                  height={120}
+                  className="h-24 w-auto object-contain opacity-70 grayscale transition-all hover:opacity-100 hover:grayscale-0"
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-10 text-center">
+            <Button href="/nos-references" variant="primary" size="lg">
+              Nos projets
+            </Button>
+          </div>
         </div>
       </Container>
     </section>


### PR DESCRIPTION
Closes https://github.com/efficience-it/website/issues/628

La hauteur de la section a été augmentée au-delà de 80px sur les résolutions mobiles. La contrainte précédente de 80px était insuffisante pour afficher correctement le titre de la section ("Nos clients") sans troncature ou superposition.

<img width="395" height="699" alt="Capture d&#39;écran 2026-04-13 164848" src="https://github.com/user-attachments/assets/1beb7796-93a3-46c0-ad01-9bf62f4cf6e3" />

<img width="397" height="697" alt="Capture d&#39;écran 2026-04-13 165134" src="https://github.com/user-attachments/assets/3567001f-bfbd-4a81-843b-a30c2d744a15" />