### PR TITLE
update

### DIFF
--- a/content/blog/api-rest-les-bonnes-pratiques.mdx
+++ b/content/blog/api-rest-les-bonnes-pratiques.mdx
@@ -2,7 +2,7 @@
 title: "API REST en PHP : bonnes pratiques pour concevoir des applications professionnelles"
 date: "2023-07-18"
 author: "Efficience IT"
-category: "Formation"
+category: "PHP"
 excerpt: "Dans le monde du web, API est l'acronyme d'Application Programming Interface, traduit en français par interface de programmation d'application."
 image: "/images/blog/api-rest.webp"
 updatedAt: "2026-01-13"

--- a/content/blog/arrives-au-max-des-id-int-2147483647.mdx
+++ b/content/blog/arrives-au-max-des-id-int-2147483647.mdx
@@ -2,7 +2,7 @@
 title: "Arrivés au max des ID INT (2 147 483 647) : comment migrer vers BIGINT"
 date: "2022-02-11"
 author: "Louis-Arnaud Catoire"
-category: "Formation"
+category: "Architecture"
 excerpt: "Les développeurs rencontrent le défi d'atteindre la limite maximale des identifiants INT dans MySQL. Quand cela se produit, tout se bloque."
 image: "/images/blog/mysql-max-id.webp"
 proficiencyLevel: "Expert"

--- a/content/blog/guide-de-migration-dans-un-projet-symfony.mdx
+++ b/content/blog/guide-de-migration-dans-un-projet-symfony.mdx
@@ -2,7 +2,7 @@
 title: "Guide pratique : réussir une montée de version Symfony"
 date: "2023-07-17"
 author: "Efficience IT"
-category: "Formation"
+category: "Symfony"
 excerpt: "Le framework Symfony est en constante évolution comme de nombreux aspects du développement web. Efficience IT surveille ces changements de près."
 image: "/images/blog/migration-symfony.webp"
 proficiencyLevel: "Expert"

--- a/content/blog/les-bundles-les-plus-utilises-dans-les-projets-symfony.mdx
+++ b/content/blog/les-bundles-les-plus-utilises-dans-les-projets-symfony.mdx
@@ -2,7 +2,7 @@
 title: "Bundles Symfony les plus utilisés : incontournables pour vos projets"
 date: "2023-07-18"
 author: "Efficience IT"
-category: "Formation"
+category: "Symfony"
 excerpt: "Les bundles, ou packages en français, désignent un regroupement de plusieurs fichiers ou logiciels livrés comme un ensemble logique de fonctionnalités."
 image: "/images/blog/bundles-symfony.webp"
 updatedAt: "2026-01-13"

--- a/content/blog/monter-en-competence-claude-code.mdx
+++ b/content/blog/monter-en-competence-claude-code.mdx
@@ -2,7 +2,7 @@
 title: "Comment monter en compétence sur Claude Code"
 date: "2026-03-29"
 author: "Efficience IT"
-category: "Formation"
+category: "IA"
 excerpt: "CLAUDE.md, skills, hooks, serveurs MCP : les fonctionnalités clés de Claude Code et les bonnes pratiques pour devenir un utilisateur avancé."
 image: "/images/blog/monter-en-competence-claude-code.webp"
 proficiencyLevel: "Beginner"

--- a/content/blog/que-vaut-rest-face-a-son-nouveau-challenger-graphql.mdx
+++ b/content/blog/que-vaut-rest-face-a-son-nouveau-challenger-graphql.mdx
@@ -2,7 +2,7 @@
 title: "Que vaut REST face à son nouveau challenger GraphQL ?"
 date: "2022-02-11"
 author: "Louis-Arnaud Catoire"
-category: "Formation"
+category: "Architecture"
 excerpt: "REST s'est imposé comme un style architectural dominant pour la transmission de données via HTTP. GraphQL est positionné comme son remplaçant."
 image: "/images/blog/rest-vs-graphql.webp"
 updatedAt: "2026-01-13"

--- a/content/blog/quelles-sont-les-differences-entre-symfony-messenger-php-enqueue-quoi-utiliser.mdx
+++ b/content/blog/quelles-sont-les-differences-entre-symfony-messenger-php-enqueue-quoi-utiliser.mdx
@@ -3,7 +3,7 @@ title: "Symfony Messenger vs PHP Enqueue : le verdict en 2026"
 date: "2026-03-10"
 updatedAt: "2026-03-26"
 author: "Louis-Arnaud Catoire"
-category: "Formation"
+category: "Symfony"
 excerpt: "PHP Enqueue est quasi abandonné depuis 2023. Symfony Messenger s'est imposé comme le standard du messaging asynchrone en PHP."
 image: "/images/blog/messenger-vs-enqueue.webp"
 ---

--- a/content/blog/symfony-pour-les-moldus.mdx
+++ b/content/blog/symfony-pour-les-moldus.mdx
@@ -2,7 +2,7 @@
 title: "Symfony pour les moldus"
 date: "2022-02-11"
 author: "Louis-Arnaud Catoire"
-category: "Formation"
+category: "Symfony"
 excerpt: "Symfony est un framework écrit en PHP. Découvrez pourquoi les développeurs l'utilisent et quels sont ses avantages pour vos projets web."
 image: "/images/blog/symfony-moldus.webp"
 proficiencyLevel: "Beginner"

--- a/content/blog/tout-savoir-sur-la-mise-en-cache-tips.mdx
+++ b/content/blog/tout-savoir-sur-la-mise-en-cache-tips.mdx
@@ -2,7 +2,7 @@
 title: "Tout savoir sur la mise en cache"
 date: "2022-11-23"
 author: "Louis-Arnaud Catoire"
-category: "Formation"
+category: "Architecture"
 excerpt: "Le cache fonctionne comme la RAM : c'est un type de mémoire conçu pour booster les performances. Découvrez les principes, usages et bonnes pratiques."
 image: "/images/blog/mise-en-cache.webp"
 updatedAt: "2026-01-13"

--- a/src/__tests__/lib/blog.test.ts
+++ b/src/__tests__/lib/blog.test.ts
@@ -8,6 +8,7 @@ import {
   getCategories,
   getPostsByCategory,
   extractHeadings,
+  isSymfonyAuditCategory,
   isTechCategory,
   readingTime,
 } from "@/lib/blog";
@@ -171,6 +172,22 @@ describe("isTechCategory", () => {
     "classifies %s as non-tech",
     (category) => {
       expect(isTechCategory(category)).toBe(false);
+    },
+  );
+});
+
+describe("isSymfonyAuditCategory", () => {
+  it.each(["Symfony", "PHP", "Architecture", "Qualité de code"])(
+    "matches %s",
+    (category) => {
+      expect(isSymfonyAuditCategory(category)).toBe(true);
+    },
+  );
+
+  it.each(["IA", "JavaScript", "DevOps", "Sécurité", "Formation", "Projet", ""])(
+    "does not match %s",
+    (category) => {
+      expect(isSymfonyAuditCategory(category)).toBe(false);
     },
   );
 });

--- a/src/__tests__/lib/blog.test.ts
+++ b/src/__tests__/lib/blog.test.ts
@@ -8,6 +8,7 @@ import {
   getCategories,
   getPostsByCategory,
   extractHeadings,
+  isTechCategory,
   readingTime,
 } from "@/lib/blog";
 
@@ -150,6 +151,28 @@ describe("extractHeadings", () => {
     expect(headings).toHaveLength(1);
     expect(headings[0].text).toBe("Valid");
   });
+});
+
+describe("isTechCategory", () => {
+  it.each([
+    "Symfony",
+    "PHP",
+    "Architecture",
+    "DevOps",
+    "Qualité de code",
+    "Sécurité",
+    "IA",
+    "JavaScript",
+  ])("classifies %s as tech", (category) => {
+    expect(isTechCategory(category)).toBe(true);
+  });
+
+  it.each(["Formation", "Projet", "Green IT", "Agence", ""])(
+    "classifies %s as non-tech",
+    (category) => {
+      expect(isTechCategory(category)).toBe(false);
+    },
+  );
 });
 
 describe("readingTime", () => {

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { getAllPosts, getPostBySlug, getCategorySlug, getPostsByCategory, extractHeadings, readingTime } from "@/lib/blog";
+import { getAllPosts, getPostBySlug, getCategorySlug, getPostsByCategory, extractHeadings, isTechCategory, readingTime } from "@/lib/blog";
 import Container from "@/components/ui/Container";
 import Button from "@/components/ui/Button";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -22,17 +22,6 @@ import {
 import { getAuthorSchema } from "@/data/authors";
 import FadeIn from "@/components/ui/FadeIn";
 import ScrollDepthTracker from "@/components/ui/ScrollDepthTracker";
-
-const TECH_CATEGORIES = [
-  "Symfony",
-  "PHP",
-  "Architecture",
-  "DevOps",
-  "Qualité de code",
-  "Sécurité",
-  "IA",
-  "JavaScript",
-];
 
 function splitContentAfterThirdH2(content: string): [string, string] | null {
   const h2Regex = /^## /gm;
@@ -99,7 +88,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 
   const url = `${BASE_URL}/article/${slug}`;
 
-  const isTech = TECH_CATEGORIES.includes(post.category);
+  const isTech = isTechCategory(post.category);
 
   const headings = extractHeadings(post.content);
 
@@ -249,25 +238,26 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
                     return <MarkdownContent content={post.content} />;
                   }
                   const [firstPart, secondPart] = parts;
-                  const isSymfony =
-                    post.category && TECH_CATEGORIES.includes(post.category);
+                  const wantsSymfonyAudit = ["Symfony", "PHP", "Architecture", "Qualité de code"].includes(
+                    post.category,
+                  );
                   return (
                     <>
                       <MarkdownContent content={firstPart} />
                       <div className="my-8 rounded-lg bg-primary/5 p-6 text-center">
                         <p className="font-display text-lg font-semibold text-dark">
-                          {isSymfony
+                          {wantsSymfonyAudit
                             ? "Besoin d'un regard expert sur votre code Symfony ?"
                             : "Besoin d'accompagnement sur votre projet ?"}
                         </p>
                         <Button
                           href={
-                            isSymfony ? "/audit-symfony-gratuit" : "/contact"
+                            wantsSymfonyAudit ? "/audit-symfony-gratuit" : "/contact"
                           }
                           className="mt-3"
                           variant="outline"
                         >
-                          {isSymfony
+                          {wantsSymfonyAudit
                             ? "Demander un audit gratuit"
                             : "Parlons-en"}
                         </Button>

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -23,7 +23,16 @@ import { getAuthorSchema } from "@/data/authors";
 import FadeIn from "@/components/ui/FadeIn";
 import ScrollDepthTracker from "@/components/ui/ScrollDepthTracker";
 
-const TECH_CATEGORIES = ["Outils", "Formation", "Projet", "Green IT"];
+const TECH_CATEGORIES = [
+  "Symfony",
+  "PHP",
+  "Architecture",
+  "DevOps",
+  "Qualité de code",
+  "Sécurité",
+  "IA",
+  "JavaScript",
+];
 
 function splitContentAfterThirdH2(content: string): [string, string] | null {
   const h2Regex = /^## /gm;

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { getAllPosts, getPostBySlug, getCategorySlug, getPostsByCategory, extractHeadings, isTechCategory, readingTime } from "@/lib/blog";
+import { getAllPosts, getPostBySlug, getCategorySlug, getPostsByCategory, extractHeadings, isSymfonyAuditCategory, isTechCategory, readingTime } from "@/lib/blog";
 import Container from "@/components/ui/Container";
 import Button from "@/components/ui/Button";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -238,9 +238,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
                     return <MarkdownContent content={post.content} />;
                   }
                   const [firstPart, secondPart] = parts;
-                  const wantsSymfonyAudit = ["Symfony", "PHP", "Architecture", "Qualité de code"].includes(
-                    post.category,
-                  );
+                  const wantsSymfonyAudit = isSymfonyAuditCategory(post.category);
                   return (
                     <>
                       <MarkdownContent content={firstPart} />

--- a/src/app/blog/[category]/page.tsx
+++ b/src/app/blog/[category]/page.tsx
@@ -16,21 +16,28 @@ import FadeIn from "@/components/ui/FadeIn";
 import CallToAction from "@/components/sections/CallToAction";
 
 const categoryDescriptions: Record<string, string> = {
+  Agence:
+    "Vie d'agence, recrutement et organisation : les coulisses d'Efficience IT.",
   Architecture:
     "Patterns et décisions techniques : architecture hexagonale, microservices, DDD, CQRS et conception d'applications maintenables.",
-  Outils:
-    "Symfony, PHP, Docker, CI/CD : nos guides pratiques sur les outils que nous utilisons au quotidien en mission.",
+  DevOps:
+    "Pipelines CI/CD, conteneurisation, infrastructure as code et déploiement continu pour des stacks PHP et Symfony fiables.",
   Formation:
     "Montée en compétences, certifications et événements tech : ressources pour progresser sur Symfony et l'écosystème PHP.",
+  "Green IT":
+    "Éco-conception web, sobriété numérique et bonnes pratiques pour réduire l'impact environnemental de vos applications.",
+  IA: "Intelligence artificielle appliquée au développement web : LLM, RAG, agents et intégration dans vos projets Symfony.",
+  JavaScript:
+    "Frameworks JavaScript modernes : Node.js, React, Vue.js, Next.js et bonnes pratiques pour des interfaces performantes.",
   PHP: "L'écosystème PHP : évolution du langage, standards PSR, outils d'analyse statique et runtime.",
   Projet:
     "Retours de mission, architecture logicielle et bonnes pratiques pour mener à bien vos projets web.",
-  Agence:
-    "Vie d'agence, recrutement et organisation : les coulisses d'Efficience IT.",
-  "Green IT":
-    "Éco-conception web, sobriété numérique et bonnes pratiques pour réduire l'impact environnemental de vos applications.",
   "Qualité de code":
     "Analyse statique, tests, conventions et outils pour produire un code PHP fiable et maintenable.",
+  Symfony:
+    "Le framework Symfony en profondeur : composants, bonnes pratiques, montées de version et architecture pour applications professionnelles.",
+  "Sécurité":
+    "Sécurité applicative : OWASP, authentification, gestion des secrets, audits et bonnes pratiques pour vos applications web.",
 };
 
 interface BlogCategoryPageProps {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -93,6 +93,21 @@ export const categorySlugMap: Record<string, string> = {
   "Sécurité": "securite",
 };
 
+const TECH_CATEGORIES = new Set([
+  "Symfony",
+  "PHP",
+  "Architecture",
+  "DevOps",
+  "Qualité de code",
+  "Sécurité",
+  "IA",
+  "JavaScript",
+]);
+
+export function isTechCategory(category: string): boolean {
+  return TECH_CATEGORIES.has(category);
+}
+
 const slugToCategoryMap: Record<string, string> = Object.fromEntries(
   Object.entries(categorySlugMap).map(([name, slug]) => [slug, name]),
 );

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -104,8 +104,19 @@ const TECH_CATEGORIES = new Set([
   "JavaScript",
 ]);
 
+const SYMFONY_AUDIT_CATEGORIES = new Set([
+  "Symfony",
+  "PHP",
+  "Architecture",
+  "Qualité de code",
+]);
+
 export function isTechCategory(category: string): boolean {
   return TECH_CATEGORIES.has(category);
+}
+
+export function isSymfonyAuditCategory(category: string): boolean {
+  return SYMFONY_AUDIT_CATEGORIES.has(category);
 }
 
 const slugToCategoryMap: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
Closes #685

## Summary
- `isTechCategory()` extrait dans `src/lib/blog.ts` (testé)
- `isSymfonyAuditCategory()` extrait pour le scope du CTA inline (testé)
- 9 articles techniques recatégorisés depuis `Formation` vers leur catégorie propre (Symfony / PHP / Architecture / IA)
- `categoryDescriptions` complété pour Symfony / DevOps / IA / JavaScript / Sécurité ; clé morte `Outils` retirée
- `isSymfony` renommé `wantsSymfonyAudit` avec scope rétréci

Effet : ~50 articles techniques basculent de `BlogPosting` à `TechArticle`. Les articles JS/IA/DevOps/Sécurité gardent un `@type` correct sans hériter du CTA Symfony hors-sujet.