### PR TITLE
update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+chrome/

--- a/src/__tests__/lib/__snapshots__/structured-data.snapshots.test.ts.snap
+++ b/src/__tests__/lib/__snapshots__/structured-data.snapshots.test.ts.snap
@@ -450,13 +450,15 @@ exports[`structured-data snapshots pageGraphJsonLd strips @context and wraps in 
   "@context": "https://schema.org",
   "@graph": [
     {
+      "@id": "https://www.itefficience.com/test#webpage",
       "@type": "WebPage",
+      "about": {
+        "@id": "https://www.itefficience.com/#organization",
+      },
       "description": "Test page",
       "inLanguage": "fr-FR",
       "isPartOf": {
-        "@type": "WebSite",
-        "name": "Efficience IT",
-        "url": "https://www.itefficience.com",
+        "@id": "https://www.itefficience.com/#website",
       },
       "name": "Test",
       "url": "https://www.itefficience.com/test",
@@ -493,8 +495,6 @@ exports[`structured-data snapshots reviewsJsonLd 1`] = `
     },
     "itemReviewed": {
       "@id": "https://www.itefficience.com/#organization",
-      "@type": "ProfessionalService",
-      "name": "Efficience IT",
     },
     "reviewBody": "Excellent.",
   },
@@ -507,8 +507,6 @@ exports[`structured-data snapshots reviewsJsonLd 1`] = `
     },
     "itemReviewed": {
       "@id": "https://www.itefficience.com/#organization",
-      "@type": "ProfessionalService",
-      "name": "Efficience IT",
     },
     "reviewBody": "Très réactif.",
   },
@@ -549,8 +547,6 @@ exports[`structured-data snapshots serviceJsonLd 1`] = `
   "name": "Audit Symfony",
   "provider": {
     "@id": "https://www.itefficience.com/#organization",
-    "@type": "ProfessionalService",
-    "name": "Efficience IT",
   },
   "url": "https://www.itefficience.com/audit-symfony-gratuit",
 }
@@ -559,13 +555,15 @@ exports[`structured-data snapshots serviceJsonLd 1`] = `
 exports[`structured-data snapshots webPageJsonLd minimal 1`] = `
 {
   "@context": "https://schema.org",
+  "@id": "https://www.itefficience.com/contact#webpage",
   "@type": "WebPage",
+  "about": {
+    "@id": "https://www.itefficience.com/#organization",
+  },
   "description": "Contactez-nous.",
   "inLanguage": "fr-FR",
   "isPartOf": {
-    "@type": "WebSite",
-    "name": "Efficience IT",
-    "url": "https://www.itefficience.com",
+    "@id": "https://www.itefficience.com/#website",
   },
   "name": "Contact",
   "url": "https://www.itefficience.com/contact",
@@ -575,15 +573,17 @@ exports[`structured-data snapshots webPageJsonLd minimal 1`] = `
 exports[`structured-data snapshots webPageJsonLd with type and dates 1`] = `
 {
   "@context": "https://schema.org",
+  "@id": "https://www.itefficience.com/blog#webpage",
   "@type": "CollectionPage",
+  "about": {
+    "@id": "https://www.itefficience.com/#organization",
+  },
   "dateModified": "2026-04-28",
   "datePublished": "2024-01-01",
   "description": "Tous les articles.",
   "inLanguage": "fr-FR",
   "isPartOf": {
-    "@type": "WebSite",
-    "name": "Efficience IT",
-    "url": "https://www.itefficience.com",
+    "@id": "https://www.itefficience.com/#website",
   },
   "name": "Blog",
   "url": "https://www.itefficience.com/blog",

--- a/src/__tests__/lib/__snapshots__/structured-data.snapshots.test.ts.snap
+++ b/src/__tests__/lib/__snapshots__/structured-data.snapshots.test.ts.snap
@@ -209,6 +209,114 @@ exports[`structured-data snapshots faqPageJsonLd 1`] = `
 }
 `;
 
+exports[`structured-data snapshots globalGraphJsonLd 1`] = `
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@id": "https://www.itefficience.com/#organization",
+      "@type": "ProfessionalService",
+      "address": {
+        "@type": "PostalAddress",
+        "addressCountry": "FR",
+        "addressLocality": "Lille",
+        "postalCode": "59800",
+        "streetAddress": "677 Avenue de la République",
+      },
+      "areaServed": [
+        {
+          "@type": "Country",
+          "name": "France",
+        },
+        {
+          "@type": "Country",
+          "name": "Belgique",
+        },
+        {
+          "@type": "Country",
+          "name": "United Kingdom",
+        },
+        {
+          "@type": "Country",
+          "name": "Luxembourg",
+        },
+        {
+          "@type": "Country",
+          "name": "Spain",
+        },
+        {
+          "@type": "Country",
+          "name": "Germany",
+        },
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "availableLanguage": [
+          "French",
+          "English",
+        ],
+        "contactType": "customer service",
+        "email": "contact@itefficience.com",
+      },
+      "description": "Agence spécialisée Symfony et PHP, Efficience IT conçoit et développe des applications web sur mesure.",
+      "email": "contact@itefficience.com",
+      "foundingDate": "2018",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 50.6292,
+        "longitude": 3.0573,
+      },
+      "image": "https://www.itefficience.com/images/logo/logo-bleu.webp",
+      "knowsAbout": [
+        "Symfony",
+        "PHP",
+        "Architecture hexagonale",
+        "Domain-Driven Design",
+        "API Platform",
+        "DevOps",
+        "Docker",
+        "Node.js",
+      ],
+      "logo": "https://www.itefficience.com/images/logo/logo-bleu.webp",
+      "name": "Efficience IT",
+      "numberOfEmployees": {
+        "@type": "QuantitativeValue",
+        "value": 15,
+      },
+      "openingHoursSpecification": [
+        {
+          "@type": "OpeningHoursSpecification",
+          "closes": "18:00",
+          "dayOfWeek": [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+          ],
+          "opens": "09:00",
+        },
+      ],
+      "priceRange": "$$",
+      "sameAs": [
+        "https://github.com/efficience-it",
+        "https://www.linkedin.com/company/efficience-it",
+      ],
+      "url": "https://www.itefficience.com",
+    },
+    {
+      "@id": "https://www.itefficience.com/#website",
+      "@type": "WebSite",
+      "name": "Efficience IT",
+      "publisher": {
+        "@id": "https://www.itefficience.com/#organization",
+      },
+      "url": "https://www.itefficience.com",
+    },
+  ],
+}
+`;
+
 exports[`structured-data snapshots howToJsonLd 1`] = `
 {
   "@context": "https://schema.org",
@@ -337,6 +445,43 @@ exports[`structured-data snapshots organizationJsonLd 1`] = `
 }
 `;
 
+exports[`structured-data snapshots pageGraphJsonLd strips @context and wraps in @graph 1`] = `
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "description": "Test page",
+      "inLanguage": "fr-FR",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "Efficience IT",
+        "url": "https://www.itefficience.com",
+      },
+      "name": "Test",
+      "url": "https://www.itefficience.com/test",
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "item": "https://www.itefficience.com",
+          "name": "Accueil",
+          "position": 1,
+        },
+        {
+          "@type": "ListItem",
+          "item": "https://www.itefficience.com/test",
+          "name": "Test",
+          "position": 2,
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`structured-data snapshots reviewsJsonLd 1`] = `
 [
   {
@@ -448,8 +593,12 @@ exports[`structured-data snapshots webPageJsonLd with type and dates 1`] = `
 exports[`structured-data snapshots websiteJsonLd 1`] = `
 {
   "@context": "https://schema.org",
+  "@id": "https://www.itefficience.com/#website",
   "@type": "WebSite",
   "name": "Efficience IT",
+  "publisher": {
+    "@id": "https://www.itefficience.com/#organization",
+  },
   "url": "https://www.itefficience.com",
 }
 `;

--- a/src/__tests__/lib/structured-data.snapshots.test.ts
+++ b/src/__tests__/lib/structured-data.snapshots.test.ts
@@ -4,8 +4,10 @@ import {
   breadcrumbJsonLd,
   eventJsonLd,
   faqPageJsonLd,
+  globalGraphJsonLd,
   howToJsonLd,
   organizationJsonLd,
+  pageGraphJsonLd,
   reviewsJsonLd,
   serviceJsonLd,
   webPageJsonLd,
@@ -20,6 +22,27 @@ describe("structured-data snapshots", () => {
 
   it("websiteJsonLd", () => {
     expect(websiteJsonLd).toMatchSnapshot();
+  });
+
+  it("globalGraphJsonLd", () => {
+    expect(globalGraphJsonLd).toMatchSnapshot();
+  });
+
+  it("pageGraphJsonLd strips @context and wraps in @graph", () => {
+    const webPage = webPageJsonLd({
+      name: "Test",
+      description: "Test page",
+      path: "/test",
+    });
+    const breadcrumb = breadcrumbJsonLd([{ name: "Test", path: "/test" }]);
+    expect(pageGraphJsonLd(webPage, breadcrumb)).toMatchSnapshot();
+  });
+
+  it("pageGraphJsonLd with no items returns empty graph", () => {
+    expect(pageGraphJsonLd()).toEqual({
+      "@context": "https://schema.org",
+      "@graph": [],
+    });
   });
 
   it("breadcrumbJsonLd", () => {

--- a/src/__tests__/lib/structured-data.snapshots.test.ts
+++ b/src/__tests__/lib/structured-data.snapshots.test.ts
@@ -45,6 +45,16 @@ describe("structured-data snapshots", () => {
     });
   });
 
+  it("pageGraphJsonLd flattens arrays passed as items", () => {
+    const reviews = reviewsJsonLd([
+      { name: "A", role: "CTO", company: "X", quote: "Q1" },
+      { name: "B", role: "Dev", company: "Y", quote: "Q2" },
+    ]);
+    const result = pageGraphJsonLd(reviews);
+    expect(result["@graph"]).toHaveLength(2);
+    expect(result["@graph"][0]).not.toHaveProperty("@context");
+  });
+
   it("breadcrumbJsonLd", () => {
     expect(
       breadcrumbJsonLd([

--- a/src/__tests__/lib/structured-data.test.ts
+++ b/src/__tests__/lib/structured-data.test.ts
@@ -36,10 +36,9 @@ describe("serviceJsonLd", () => {
       description: "Description",
       path: "/service",
     });
-    expect(result.provider["@id"]).toBe(
-      "https://www.itefficience.com/#organization",
-    );
-    expect(result.provider["@type"]).toBe("ProfessionalService");
+    expect(result.provider).toEqual({
+      "@id": "https://www.itefficience.com/#organization",
+    });
   });
 });
 
@@ -48,10 +47,9 @@ describe("reviewsJsonLd", () => {
     const result = reviewsJsonLd([
       { name: "X", role: "CEO", company: "Acme", quote: "Great" },
     ]);
-    expect(result[0].itemReviewed["@id"]).toBe(
-      "https://www.itefficience.com/#organization",
-    );
-    expect(result[0].itemReviewed["@type"]).toBe("ProfessionalService");
+    expect(result[0].itemReviewed).toEqual({
+      "@id": "https://www.itefficience.com/#organization",
+    });
   });
 });
 

--- a/src/app/accompagnement-et-conseil/page.tsx
+++ b/src/app/accompagnement-et-conseil/page.tsx
@@ -15,7 +15,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { clients } from "@/../data/clients";
 import { testimonials } from "@/../data/testimonials";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Conseil et coaching technique Symfony pour vos équipes",
@@ -148,22 +148,7 @@ const accompagnementRelatedLinks: RelatedLink[] = [
 export default function AccompagnementEtConseil() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
     <main>
       {/* Hero */}
       <section className="bg-light-gray py-16 md:py-24">

--- a/src/app/agence-symfony-france/page.tsx
+++ b/src/app/agence-symfony-france/page.tsx
@@ -11,7 +11,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -158,18 +158,7 @@ const relatedLinks: RelatedLink[] = [
 export default function AgenceSymfonyFrance() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/agence-symfony-lille/page.tsx
+++ b/src/app/agence-symfony-lille/page.tsx
@@ -11,7 +11,7 @@ import Accordion from "@/components/ui/Accordion";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Agence Symfony à Lille, votre partenaire développement web",
@@ -120,18 +120,7 @@ const agenceRelatedLinks: RelatedLink[] = [
 export default function AgenceSymfonyLille() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/agence-symfony-lyon/page.tsx
+++ b/src/app/agence-symfony-lyon/page.tsx
@@ -11,7 +11,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Agence Symfony à Lyon : expertise PHP et développement sur mesure",
@@ -158,18 +158,7 @@ const relatedLinks: RelatedLink[] = [
 export default function AgenceSymfonyLyon() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/agence-symfony-nantes/page.tsx
+++ b/src/app/agence-symfony-nantes/page.tsx
@@ -11,7 +11,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Agence Symfony à Nantes : développement PHP et expertise technique",
@@ -158,18 +158,7 @@ const relatedLinks: RelatedLink[] = [
 export default function AgenceSymfonyNantes() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/agence-symfony-paris/page.tsx
+++ b/src/app/agence-symfony-paris/page.tsx
@@ -11,7 +11,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Agence Symfony à Paris : développement PHP sur mesure",
@@ -158,18 +158,7 @@ const relatedLinks: RelatedLink[] = [
 export default function AgenceSymfonyParis() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/api-nodejs-nestjs/page.tsx
+++ b/src/app/api-nodejs-nestjs/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -176,22 +176,7 @@ const webPage = webPageJsonLd({
 export default function ApiNodejsNestjs() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/api-sur-mesure-symfony/page.tsx
+++ b/src/app/api-sur-mesure-symfony/page.tsx
@@ -10,7 +10,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "API sur mesure avec Symfony et API Platform",
@@ -217,22 +217,7 @@ const apiRelatedLinks: RelatedLink[] = [
 export default function ApiSurMesureSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/architecture-hexagonale-symfony/page.tsx
+++ b/src/app/architecture-hexagonale-symfony/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import CodeThinkingIllustration from "@/components/illustrations/CodeThinkingIllustration";
 
 export const metadata = pageMetadata({
@@ -201,22 +201,7 @@ const architectureRelatedLinks: RelatedLink[] = [
 export default function ArchitectureHexagonaleSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -18,6 +18,7 @@ import {
   eventJsonLd,
   faqPageJsonLd,
   howToJsonLd,
+  pageGraphJsonLd,
 } from "@/lib/structured-data";
 import { getAuthorSchema } from "@/data/authors";
 import FadeIn from "@/components/ui/FadeIn";
@@ -118,46 +119,27 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     { name: post.title, path: `/article/${slug}` },
   ]);
 
+  const articleGraphItems: Array<Record<string, unknown>> = [jsonLd, breadcrumb];
+  if (post.event) {
+    articleGraphItems.push(eventJsonLd(post.event));
+  }
+  if (post.howTo && post.howTo.steps.length > 0) {
+    articleGraphItems.push(
+      howToJsonLd(post.howTo.name, post.howTo.description, post.howTo.steps),
+    );
+  }
+  if (post.faq && post.faq.length > 0) {
+    articleGraphItems.push(faqPageJsonLd(post.faq));
+  }
+
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(pageGraphJsonLd(...articleGraphItems)),
+        }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      {post.event && (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(eventJsonLd(post.event)),
-          }}
-        />
-      )}
-      {post.howTo && post.howTo.steps.length > 0 && (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(
-              howToJsonLd(
-                post.howTo.name,
-                post.howTo.description,
-                post.howTo.steps,
-              ),
-            ),
-          }}
-        />
-      )}
-      {post.faq && post.faq.length > 0 && (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(faqPageJsonLd(post.faq)),
-          }}
-        />
-      )}
       <ScrollDepthTracker slug={slug} />
       <main>
         <article className="py-16">

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -119,26 +119,21 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     { name: post.title, path: `/article/${slug}` },
   ]);
 
-  const articleGraphItems: Array<Record<string, unknown>> = [jsonLd, breadcrumb];
-  if (post.event) {
-    articleGraphItems.push(eventJsonLd(post.event));
-  }
-  if (post.howTo && post.howTo.steps.length > 0) {
-    articleGraphItems.push(
-      howToJsonLd(post.howTo.name, post.howTo.description, post.howTo.steps),
-    );
-  }
-  if (post.faq && post.faq.length > 0) {
-    articleGraphItems.push(faqPageJsonLd(post.faq));
-  }
+  const graph = pageGraphJsonLd(
+    jsonLd,
+    breadcrumb,
+    ...(post.event ? [eventJsonLd(post.event)] : []),
+    ...(post.howTo && post.howTo.steps.length > 0
+      ? [howToJsonLd(post.howTo.name, post.howTo.description, post.howTo.steps)]
+      : []),
+    ...(post.faq && post.faq.length > 0 ? [faqPageJsonLd(post.faq)] : []),
+  );
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(pageGraphJsonLd(...articleGraphItems)),
-        }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
       />
       <ScrollDepthTracker slug={slug} />
       <main>

--- a/src/app/audit-code-php/page.tsx
+++ b/src/app/audit-code-php/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Audit technique approfondi de code PHP : rapport détaillé et plan d'action",
@@ -172,22 +172,7 @@ const auditRelatedLinks: RelatedLink[] = [
 export default function AuditCodePhp() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/audit-ia-entreprise/page.tsx
+++ b/src/app/audit-ia-entreprise/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import StrategyIllustration from "@/components/illustrations/StrategyIllustration";
 
 export const metadata = pageMetadata({
@@ -207,22 +207,7 @@ const auditIaRelatedLinks: RelatedLink[] = [
 export default function AuditIaEntreprise() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/audit-symfony-gratuit/page.tsx
+++ b/src/app/audit-symfony-gratuit/page.tsx
@@ -9,7 +9,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, howToJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, howToJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import CodeIllustration from "@/components/illustrations/CodeIllustration";
 
 export const metadata = pageMetadata({
@@ -156,22 +156,7 @@ const auditRelatedLinks: RelatedLink[] = [
 export default function AuditSymfonyGratuit() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, howTo, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/base-de-donnees-postgresql-symfony/page.tsx
+++ b/src/app/base-de-donnees-postgresql-symfony/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -177,22 +177,7 @@ const webPage = webPageJsonLd({
 export default function BaseDeDonneesPostgresqlSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/blog/[category]/page.tsx
+++ b/src/app/blog/[category]/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/blog";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import FadeIn from "@/components/ui/FadeIn";
 import CallToAction from "@/components/sections/CallToAction";
 
@@ -90,7 +90,7 @@ export default async function BlogCategoryPage({
     <>
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb)) }}
     />
     <main>
       <section className="bg-light-gray py-16 md:py-24">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -5,7 +5,7 @@ import { getAllPosts, getCategories, getCategorySlug } from "@/lib/blog";
 import Link from "next/link";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, blogItemListJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, blogItemListJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import CallToAction from "@/components/sections/CallToAction";
 
 export const metadata = pageMetadata({
@@ -33,18 +33,7 @@ export default function BlogPage() {
 
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, itemList, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container className="text-center">

--- a/src/app/cloud-et-devops/page.tsx
+++ b/src/app/cloud-et-devops/page.tsx
@@ -15,7 +15,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { clients } from "@/../data/clients";
 import { testimonials } from "@/../data/testimonials";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import GrowthIllustration from "@/components/illustrations/GrowthIllustration";
 
 export const metadata = pageMetadata({
@@ -138,22 +138,7 @@ const cloudRelatedLinks: RelatedLink[] = [
 export default function CloudEtDevops() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
     <main>
       {/* Hero */}
       <section className="bg-light-gray py-16 md:py-24">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -7,7 +7,7 @@ import ContactForm from "@/components/sections/ContactForm";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { faqItems } from "@/../data/faq";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Contact | Agence web Symfony – Efficience IT",
@@ -44,18 +44,7 @@ const webPage = webPageJsonLd({
 export default function Contact() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(jsonLd, breadcrumb, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container className="text-center">

--- a/src/app/developpement-frontend/page.tsx
+++ b/src/app/developpement-frontend/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import CreativeIllustration from "@/components/illustrations/CreativeIllustration";
@@ -184,22 +184,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementFrontend() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-nodejs/page.tsx
+++ b/src/app/developpement-nodejs/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import DashboardIllustration from "@/components/illustrations/DashboardIllustration";
@@ -143,22 +143,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementNodejs() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-php/page.tsx
+++ b/src/app/developpement-php/page.tsx
@@ -9,11 +9,9 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import {
-  breadcrumbJsonLd,
+import { breadcrumbJsonLd,
   serviceJsonLd,
-  webPageJsonLd,
-} from "@/lib/structured-data";
+  webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import ProgrammingIllustration from "@/components/illustrations/ProgrammingIllustration";
@@ -208,22 +206,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementPhp() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-react/page.tsx
+++ b/src/app/developpement-react/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -185,22 +185,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementReact() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-typescript/page.tsx
+++ b/src/app/developpement-typescript/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -191,22 +191,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementTypescript() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-vuejs/page.tsx
+++ b/src/app/developpement-vuejs/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -178,22 +178,7 @@ const webPage = webPageJsonLd({
 export default function DeveloppementVuejs() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/developpement-web-sur-mesure/page.tsx
+++ b/src/app/developpement-web-sur-mesure/page.tsx
@@ -15,7 +15,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { clients } from "@/../data/clients";
 import { testimonials } from "@/../data/testimonials";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Développement web sur mesure | Expertise Symfony – Efficience IT",
@@ -121,22 +121,7 @@ const devWebRelatedLinks: RelatedLink[] = [
 export default function DeveloppementWeb() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
     <main>
       {/* Hero */}
       <section className="bg-light-gray py-16 md:py-24">

--- a/src/app/ecommerce-sylius/page.tsx
+++ b/src/app/ecommerce-sylius/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -161,22 +161,7 @@ const relatedLinks: RelatedLink[] = [
 export default function EcommerceSylius() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/expertise-ia/page.tsx
+++ b/src/app/expertise-ia/page.tsx
@@ -15,7 +15,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { clients } from "@/../data/clients";
 import { testimonials } from "@/../data/testimonials";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import ResearchIllustration from "@/components/illustrations/ResearchIllustration";
 
 export const metadata = pageMetadata({
@@ -150,22 +150,7 @@ const expertiseIaRelatedLinks: RelatedLink[] = [
 export default function ExpertiseIa() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container>

--- a/src/app/formation-symfony-entreprise/page.tsx
+++ b/src/app/formation-symfony-entreprise/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { pageMetadata } from "@/lib/metadata";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import Container from "@/components/ui/Container";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Card from "@/components/ui/Card";
@@ -195,22 +195,7 @@ const formationRelatedLinks: RelatedLink[] = [
 export default function FormationSymfonyEntreprise() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, courseJsonLd, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/geo-optimisation-ia/page.tsx
+++ b/src/app/geo-optimisation-ia/page.tsx
@@ -11,7 +11,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "GEO : optimisez votre visibilité dans les moteurs IA",
@@ -179,22 +179,7 @@ const geoRelatedLinks: RelatedLink[] = [
 export default function GeoOptimisationIa() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/green-it/page.tsx
+++ b/src/app/green-it/page.tsx
@@ -9,7 +9,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import {
   greenMetrics,
   greenPrinciple,
@@ -65,14 +65,7 @@ const greenItRelatedLinks: RelatedLink[] = [
 export default function GreenIt() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container>

--- a/src/app/hebergement-symfony/page.tsx
+++ b/src/app/hebergement-symfony/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -161,22 +161,7 @@ const relatedLinks: RelatedLink[] = [
 export default function HebergementSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/integration-docker-symfony/page.tsx
+++ b/src/app/integration-docker-symfony/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -177,22 +177,7 @@ const webPage = webPageJsonLd({
 export default function IntegrationDockerSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/integration-elasticsearch-symfony/page.tsx
+++ b/src/app/integration-elasticsearch-symfony/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -171,22 +171,7 @@ const webPage = webPageJsonLd({
 export default function IntegrationElasticsearchSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/integration-redis-symfony/page.tsx
+++ b/src/app/integration-redis-symfony/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -172,22 +172,7 @@ const webPage = webPageJsonLd({
 export default function IntegrationRedisSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/l-entreprise/page.tsx
+++ b/src/app/l-entreprise/page.tsx
@@ -7,7 +7,7 @@ import Button from "@/components/ui/Button";
 import CallToAction from "@/components/sections/CallToAction";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import EnterpriseTimeline from "@/components/sections/EnterpriseTimeline";
@@ -139,14 +139,7 @@ const webPage = webPageJsonLd({
 export default function LEntreprise() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container>

--- a/src/app/la-team/page.tsx
+++ b/src/app/la-team/page.tsx
@@ -8,7 +8,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import PresentationIllustration from "@/components/illustrations/PresentationIllustration";
 
 export const metadata = pageMetadata({
@@ -53,14 +53,7 @@ const teamRelatedLinks: RelatedLink[] = [
 export default function LaTeam() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import GoogleAnalytics from "@/components/ui/GoogleAnalytics";
 import CookieConsent from "@/components/ui/CookieConsent";
-import { organizationJsonLd, websiteJsonLd } from "@/lib/structured-data";
+import { globalGraphJsonLd } from "@/lib/structured-data";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -38,13 +38,7 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(organizationJsonLd),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(websiteJsonLd),
+            __html: JSON.stringify(globalGraphJsonLd),
           }}
         />
         <GoogleAnalytics />

--- a/src/app/maintenance-applicative-symfony/page.tsx
+++ b/src/app/maintenance-applicative-symfony/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import ReviewIllustration from "@/components/illustrations/ReviewIllustration";
 
 export const metadata = pageMetadata({
@@ -199,22 +199,7 @@ const maintenanceRelatedLinks: RelatedLink[] = [
 export default function MaintenanceApplicativeSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/migration-symfony/page.tsx
+++ b/src/app/migration-symfony/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import StrategyIllustration from "@/components/illustrations/StrategyIllustration";
 
 export const metadata = pageMetadata({
@@ -176,22 +176,7 @@ const migrationRelatedLinks: RelatedLink[] = [
 export default function MigrationSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/modernisation-application-php/page.tsx
+++ b/src/app/modernisation-application-php/page.tsx
@@ -5,7 +5,7 @@ import SectionTitle from "@/components/ui/SectionTitle";
 import Card from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
@@ -198,22 +198,7 @@ const webPage = webPageJsonLd({
 export default function ModernisationApplicationPhp() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/modernisation-applicative/page.tsx
+++ b/src/app/modernisation-applicative/page.tsx
@@ -5,7 +5,7 @@ import SectionTitle from "@/components/ui/SectionTitle";
 import Card from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import Accordion from "@/components/ui/Accordion";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
@@ -119,22 +119,7 @@ const faqJsonLd = {
 export default function ModernisationApplicative() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, service, faqJsonLd)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/nos-references/page.tsx
+++ b/src/app/nos-references/page.tsx
@@ -7,7 +7,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd, reviewsJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, reviewsJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import CallToAction from "@/components/sections/CallToAction";
 import { testimonials } from "@/../data/testimonials";
 
@@ -118,18 +118,7 @@ const referencesRelatedLinks: RelatedLink[] = [
 export default function NosReferences() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(reviews) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, ...reviews)) }} />
     <main>
       <section className="bg-light-gray py-8 md:py-12">
         <Container className="text-center">

--- a/src/app/nos-references/page.tsx
+++ b/src/app/nos-references/page.tsx
@@ -118,7 +118,7 @@ const referencesRelatedLinks: RelatedLink[] = [
 export default function NosReferences() {
   return (
     <>
-    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, ...reviews)) }} />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage, reviews)) }} />
     <main>
       <section className="bg-light-gray py-8 md:py-12">
         <Container className="text-center">

--- a/src/app/notre-expertise/page.tsx
+++ b/src/app/notre-expertise/page.tsx
@@ -10,7 +10,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import TechnologiesGrid from "@/components/sections/TechnologiesGrid";
 import SharingIllustration from "@/components/illustrations/SharingIllustration";
 
@@ -65,14 +65,7 @@ const expertiseRelatedLinks: RelatedLink[] = [
 export default function NotreExpertise() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import AnimatedCounter from "@/components/ui/AnimatedCounter";
 
 import { pageMetadata } from "@/lib/metadata";
-import { webPageJsonLd, reviewsJsonLd } from "@/lib/structured-data";
+import { webPageJsonLd, reviewsJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import { testimonials } from "@/../data/testimonials";
 import type { Metadata } from "next";
 
@@ -45,14 +45,7 @@ const webPage = webPageJsonLd({
 export default function Home() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(reviews) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(webPage, ...reviews)) }} />
     <main>
       <Hero />
       <FadeIn>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ const webPage = webPageJsonLd({
 export default function Home() {
   return (
     <>
-    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(webPage, ...reviews)) }} />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(webPage, reviews)) }} />
     <main>
       <Hero />
       <FadeIn>

--- a/src/app/pourquoi-efficience-it/page.tsx
+++ b/src/app/pourquoi-efficience-it/page.tsx
@@ -15,7 +15,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import { clients } from "@/../data/clients";
 import { testimonials } from "@/../data/testimonials";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Pourquoi choisir Efficience IT pour vos projets Symfony",
@@ -147,18 +147,7 @@ const comparisonData = [
 export default function PourquoiEfficienceIt() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/processus-collaboration/page.tsx
+++ b/src/app/processus-collaboration/page.tsx
@@ -12,7 +12,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import Button from "@/components/ui/Button";
-import { breadcrumbJsonLd, howToJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, howToJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -225,22 +225,7 @@ const relatedLinks: RelatedLink[] = [
 export default function ProcessusCollaboration() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLdData) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, howTo, faqJsonLdData, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/reprise-projet-symfony/page.tsx
+++ b/src/app/reprise-projet-symfony/page.tsx
@@ -10,7 +10,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import FittingPieceIllustration from "@/components/illustrations/FittingPieceIllustration";
 
 export const metadata = pageMetadata({
@@ -174,22 +174,7 @@ const repriseRelatedLinks: RelatedLink[] = [
 export default function RepriseProjetSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/api-integration/page.tsx
+++ b/src/app/secteur/api-integration/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurApiIntegration() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/application-metier/page.tsx
+++ b/src/app/secteur/application-metier/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurApplicationMetier() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/e-commerce/page.tsx
+++ b/src/app/secteur/e-commerce/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -153,22 +153,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurEcommerce() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/finance/page.tsx
+++ b/src/app/secteur/finance/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurFinance() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/industrie/page.tsx
+++ b/src/app/secteur/industrie/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurIndustrie() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/maintenance-applicative/page.tsx
+++ b/src/app/secteur/maintenance-applicative/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurMaintenanceApplicative() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/migration-legacy/page.tsx
+++ b/src/app/secteur/migration-legacy/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurMigrationLegacy() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/page.tsx
+++ b/src/app/secteur/page.tsx
@@ -11,7 +11,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title: "Nos secteurs d'intervention et nos domaines d'expertise Symfony",
@@ -169,18 +169,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteursIndex() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/renfort-equipe/page.tsx
+++ b/src/app/secteur/renfort-equipe/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -153,22 +153,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurRenfortEquipe() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/saas/page.tsx
+++ b/src/app/secteur/saas/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -158,22 +158,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurSaas() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/secteur/securite-conformite/page.tsx
+++ b/src/app/secteur/securite-conformite/page.tsx
@@ -12,7 +12,7 @@ import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -159,22 +159,7 @@ const relatedLinks: RelatedLink[] = [
 export default function SecteurSecuriteConformite() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/securite-application-symfony/page.tsx
+++ b/src/app/securite-application-symfony/page.tsx
@@ -9,7 +9,7 @@ import CallToAction from "@/components/sections/CallToAction";
 import StickyMobileCta from "@/components/sections/StickyMobileCta";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 
@@ -177,22 +177,7 @@ const webPage = webPageJsonLd({
 export default function SecuriteApplicationSymfony() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/app/ta-carriere/page.tsx
+++ b/src/app/ta-carriere/page.tsx
@@ -7,7 +7,7 @@ import { jobs, domains, spontaneousEmail } from "@/../data/jobs";
 import Link from "next/link";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import CallToAction from "@/components/sections/CallToAction";
@@ -42,14 +42,7 @@ const webPage = webPageJsonLd({
 export default function TaCarriere() {
   return (
     <>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-    />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-    />
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container className="text-center">

--- a/src/app/tests-automatises-php/page.tsx
+++ b/src/app/tests-automatises-php/page.tsx
@@ -11,7 +11,7 @@ import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, serviceJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
 
 export const metadata = pageMetadata({
   title:
@@ -141,22 +141,7 @@ const testsRelatedLinks: RelatedLink[] = [
 export default function TestsAutomatisesPhp() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(service) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, service, faqJsonLd, webPage)) }} />
       <main>
         <section className="bg-light-gray py-16 md:py-24">
           <Container>

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -96,10 +96,13 @@ export const globalGraphJsonLd = {
   "@graph": [organizationEntity, websiteEntity],
 };
 
+type GraphItem = Record<string, unknown>;
+
 export function pageGraphJsonLd(
-  ...items: Array<Record<string, unknown>>
-): { "@context": string; "@graph": Array<Record<string, unknown>> } {
-  const stripped = items.map((item) => {
+  ...items: Array<GraphItem | GraphItem[]>
+): { "@context": string; "@graph": GraphItem[] } {
+  const flat = items.flat();
+  const stripped = flat.map((item) => {
     const copy = { ...item };
     delete copy["@context"];
     return copy;
@@ -144,11 +147,7 @@ export function serviceJsonLd({ name, description, path }: ServiceSchemaProps) {
     name,
     description,
     url: `${BASE_URL}${path}`,
-    provider: {
-      "@type": "ProfessionalService",
-      "@id": `${BASE_URL}/#organization`,
-      name: "Efficience IT",
-    },
+    provider: { "@id": `${BASE_URL}/#organization` },
     areaServed: [
       { "@type": "Country", name: "France" },
       { "@type": "Country", name: "Belgique" },
@@ -171,11 +170,7 @@ export function reviewsJsonLd(testimonials: Testimonial[]) {
       name: t.name,
     },
     reviewBody: t.quote,
-    itemReviewed: {
-      "@type": "ProfessionalService",
-      "@id": `${BASE_URL}/#organization`,
-      name: "Efficience IT",
-    },
+    itemReviewed: { "@id": `${BASE_URL}/#organization` },
   }));
 }
 
@@ -216,15 +211,13 @@ export function webPageJsonLd({
   return {
     "@context": "https://schema.org",
     "@type": type,
+    "@id": `${BASE_URL}${path}#webpage`,
     name,
     description,
     url: `${BASE_URL}${path}`,
     inLanguage: "fr-FR",
-    isPartOf: {
-      "@type": "WebSite",
-      name: "Efficience IT",
-      url: BASE_URL,
-    },
+    isPartOf: { "@id": `${BASE_URL}/#website` },
+    about: { "@id": `${BASE_URL}/#organization` },
     ...(datePublished && { datePublished }),
     ...(dateModified && { dateModified }),
   };

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -7,8 +7,7 @@ interface BreadcrumbItem {
   path: string;
 }
 
-export const organizationJsonLd = {
-  "@context": "https://schema.org",
+const organizationEntity = {
   "@type": "ProfessionalService",
   "@id": `${BASE_URL}/#organization`,
   name: "Efficience IT",
@@ -74,12 +73,42 @@ export const organizationJsonLd = {
   ],
 };
 
-export const websiteJsonLd = {
-  "@context": "https://schema.org",
+const websiteEntity = {
   "@type": "WebSite",
+  "@id": `${BASE_URL}/#website`,
   name: "Efficience IT",
   url: BASE_URL,
+  publisher: { "@id": `${BASE_URL}/#organization` },
 };
+
+export const organizationJsonLd = {
+  "@context": "https://schema.org",
+  ...organizationEntity,
+};
+
+export const websiteJsonLd = {
+  "@context": "https://schema.org",
+  ...websiteEntity,
+};
+
+export const globalGraphJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [organizationEntity, websiteEntity],
+};
+
+export function pageGraphJsonLd(
+  ...items: Array<Record<string, unknown>>
+): { "@context": string; "@graph": Array<Record<string, unknown>> } {
+  const stripped = items.map((item) => {
+    const copy = { ...item };
+    delete copy["@context"];
+    return copy;
+  });
+  return {
+    "@context": "https://schema.org",
+    "@graph": stripped,
+  };
+}
 
 export function breadcrumbJsonLd(items: BreadcrumbItem[]) {
   return {


### PR DESCRIPTION
Closes #671

## Summary
- 60 pages : 2-4 `<script type="application/ld+json">` consolidés en 1 seul, avec `@graph`
- État final : 2 scripts par page (1 layout pour Organization+WebSite, 1 page pour le reste) au lieu de 5-7
- Helper `pageGraphJsonLd(...items)` accepte objects ET arrays (flatten interne, plus besoin de `...spread` côté caller)
- `webPageJsonLd` gagne `@id` + cross-refs `isPartOf → @id #website` et `about → @id #organization`
- `websiteJsonLd` gagne `@id` et `publisher → @id #organization`
- `Service.provider` et `Review.itemReviewed` simplifiés en `@id` seul (référence par identifiant, plus de re-déclaration verbeuse)
- 1673 tests passent, snapshots à jour
- Net : -609 lignes