### PR TITLE
update

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -47,8 +47,6 @@ export default function Hero() {
               width={500}
               height={400}
               className="w-full max-w-md"
-              priority
-              fetchPriority="high"
             />
           </div>
         </div>


### PR DESCRIPTION
Closes #686

`priority` et `fetchPriority="high"` retirés sur l'illustration du Hero. Image masquée `hidden md:flex` (invisible sur mobile), pas le LCP de la page (c'est le H1 à gauche). Le navigateur peut maintenant prioriser correctement les assets vraiment critiques.