### PR TITLE
fix: preconnect après consentement uniquement

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,10 +33,6 @@ export default function RootLayout({
     <html lang="fr-FR" suppressHydrationWarning>
       <head>
         <link rel="ai-metadata" href="/llms.txt" />
-        <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-        <link rel="preconnect" href="https://www.google-analytics.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://www.google-analytics.com" />
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body

--- a/src/components/ui/GoogleAnalytics.tsx
+++ b/src/components/ui/GoogleAnalytics.tsx
@@ -29,6 +29,8 @@ export default function GoogleAnalytics() {
 
   return (
     <>
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
+      <link rel="preconnect" href="https://www.google-analytics.com" crossOrigin="anonymous" />
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
         strategy="afterInteractive"


### PR DESCRIPTION
## Summary
- Préconnexions Google déplacées dans `GoogleAnalytics` (déjà gated par le consentement)
- `dns-prefetch` supprimés (redondants avec `preconnect` sur le browserslist du projet)

## Pourquoi
Les `<link rel="preconnect">` ouvrent un TCP+TLS handshake → IP utilisateur transmise à Google avant action. Doit attendre le consentement explicite.