### PR TITLE
feat: schema JobPosting sur /ta-carriere

### DIFF
--- a/data/jobs.ts
+++ b/data/jobs.ts
@@ -1,8 +1,27 @@
+type EmploymentType = "FULL_TIME" | "PART_TIME" | "CONTRACTOR" | "INTERN";
+
+interface JobLocation {
+  addressLocality: string;
+  addressRegion?: string;
+  postalCode?: string;
+  addressCountry: string;
+}
+
 export interface Job {
+  slug: string;
   title: string;
   category: string;
   domain: string;
   description: string;
+  datePosted: string;
+  validThrough?: string;
+  employmentType: EmploymentType;
+  jobLocation: JobLocation;
+  jobLocationType?: "TELECOMMUTE";
+  directApply?: boolean;
+  experienceMonths?: number;
+  educationRequirements?: string;
+  skills?: string[];
 }
 
 interface Domain {

--- a/data/jobs.ts
+++ b/data/jobs.ts
@@ -19,7 +19,7 @@ export interface Job {
   jobLocation: JobLocation;
   jobLocationType?: "TELECOMMUTE";
   directApply?: boolean;
-  experienceMonths?: number;
+  experienceRequirements?: { monthsOfExperience: number };
   educationRequirements?: string;
   skills?: string[];
 }

--- a/src/__tests__/components/cards/JobCard.test.tsx
+++ b/src/__tests__/components/cards/JobCard.test.tsx
@@ -3,10 +3,14 @@ import JobCard from "@/components/cards/JobCard";
 import { Job } from "@/../data/jobs";
 
 const mockJob: Job = {
+  slug: "dev-symfony",
   title: "Dev Symfony",
   category: "Développement",
   domain: "developpement",
   description: "Poste de dev Symfony senior.",
+  datePosted: "2026-04-01",
+  employmentType: "FULL_TIME",
+  jobLocation: { addressLocality: "Lille", addressCountry: "FR" },
 };
 
 describe("JobCard", () => {

--- a/src/__tests__/data/jobs.test.ts
+++ b/src/__tests__/data/jobs.test.ts
@@ -1,4 +1,16 @@
-import { getJobsByDomain, domains, jobs, spontaneousEmail } from "../../../data/jobs";
+import { getJobsByDomain, domains, jobs, spontaneousEmail, type Job } from "../../../data/jobs";
+
+const sampleJob = (overrides: Partial<Job> = {}): Job => ({
+  slug: "dev-symfony",
+  title: "Dev Symfony",
+  category: "CDI",
+  domain: "developpement",
+  description: "desc",
+  datePosted: "2026-04-01",
+  employmentType: "FULL_TIME",
+  jobLocation: { addressLocality: "Lille", addressCountry: "FR" },
+  ...overrides,
+});
 
 describe("getJobsByDomain", () => {
   it("returns an empty array for an unknown domain", () => {
@@ -11,8 +23,8 @@ describe("getJobsByDomain", () => {
 
   it("filters jobs matching the domain slug", () => {
     jobs.push(
-      { title: "Dev Symfony", category: "CDI", domain: "developpement", description: "desc" },
-      { title: "Commercial", category: "CDI", domain: "business", description: "desc" },
+      sampleJob({ slug: "dev-symfony", title: "Dev Symfony", domain: "developpement" }),
+      sampleJob({ slug: "commercial", title: "Commercial", domain: "business" }),
     );
     const result = getJobsByDomain("developpement");
     expect(result).toHaveLength(1);

--- a/src/__tests__/lib/structured-data.test.ts
+++ b/src/__tests__/lib/structured-data.test.ts
@@ -1,5 +1,6 @@
-import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd } from "@/lib/structured-data";
+import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd, jobPostingJsonLd } from "@/lib/structured-data";
 import { categorySlugMap } from "@/lib/blog";
+import type { Job } from "@/../data/jobs";
 
 describe("howToJsonLd", () => {
   it("returns correct schema with steps", () => {
@@ -83,5 +84,59 @@ describe("categorySlugMap", () => {
     expect(categorySlugMap["Symfony"]).toBe("symfony");
     expect(categorySlugMap["Green IT"]).toBe("green-it");
     expect(Object.keys(categorySlugMap).length).toBeGreaterThan(0);
+  });
+});
+
+describe("jobPostingJsonLd", () => {
+  const baseJob: Job = {
+    slug: "dev-symfony",
+    title: "Dev Symfony",
+    category: "CDI",
+    domain: "developpement",
+    description: "Rejoignez une équipe Symfony senior à Lille.",
+    datePosted: "2026-04-01",
+    employmentType: "FULL_TIME",
+    jobLocation: { addressLocality: "Lille", addressCountry: "FR" },
+  };
+
+  it("returns the minimal valid JobPosting schema", () => {
+    const result = jobPostingJsonLd(baseJob);
+    expect(result["@type"]).toBe("JobPosting");
+    expect(result.title).toBe("Dev Symfony");
+    expect(result.datePosted).toBe("2026-04-01");
+    expect(result.employmentType).toBe("FULL_TIME");
+    expect(result.url).toContain("/ta-carriere#dev-symfony");
+    expect(result.directApply).toBe(false);
+    expect(result.validThrough).toBeUndefined();
+    expect(result.jobLocationType).toBeUndefined();
+    expect(result.experienceRequirements).toBeUndefined();
+    expect(result.educationRequirements).toBeUndefined();
+    expect(result.skills).toBeUndefined();
+  });
+
+  it("includes optional fields when provided", () => {
+    const result = jobPostingJsonLd({
+      ...baseJob,
+      validThrough: "2026-10-01",
+      jobLocationType: "TELECOMMUTE",
+      experienceMonths: 36,
+      educationRequirements: "Bac+5",
+      skills: ["Symfony", "PHP", "Doctrine"],
+      directApply: true,
+    });
+    expect(result.validThrough).toBe("2026-10-01");
+    expect(result.jobLocationType).toBe("TELECOMMUTE");
+    expect(result.experienceRequirements).toEqual({
+      "@type": "OccupationalExperienceRequirements",
+      monthsOfExperience: 36,
+    });
+    expect(result.educationRequirements).toBe("Bac+5");
+    expect(result.skills).toBe("Symfony, PHP, Doctrine");
+    expect(result.directApply).toBe(true);
+  });
+
+  it("omits skills when array is empty", () => {
+    const result = jobPostingJsonLd({ ...baseJob, skills: [] });
+    expect(result.skills).toBeUndefined();
   });
 });

--- a/src/__tests__/lib/structured-data.test.ts
+++ b/src/__tests__/lib/structured-data.test.ts
@@ -106,7 +106,8 @@ describe("jobPostingJsonLd", () => {
     expect(result.datePosted).toBe("2026-04-01");
     expect(result.employmentType).toBe("FULL_TIME");
     expect(result.url).toContain("/ta-carriere#dev-symfony");
-    expect(result.directApply).toBe(false);
+    expect(result.hiringOrganization).toEqual({ "@id": expect.stringContaining("/#organization") });
+    expect(result.directApply).toBeUndefined();
     expect(result.validThrough).toBeUndefined();
     expect(result.jobLocationType).toBeUndefined();
     expect(result.experienceRequirements).toBeUndefined();
@@ -119,7 +120,7 @@ describe("jobPostingJsonLd", () => {
       ...baseJob,
       validThrough: "2026-10-01",
       jobLocationType: "TELECOMMUTE",
-      experienceMonths: 36,
+      experienceRequirements: { monthsOfExperience: 36 },
       educationRequirements: "Bac+5",
       skills: ["Symfony", "PHP", "Doctrine"],
       directApply: true,

--- a/src/__tests__/pages.test.tsx
+++ b/src/__tests__/pages.test.tsx
@@ -161,7 +161,9 @@ jest.mock("@/../data/jobs", () => ({
   },
 }));
 
-let mockJobs: Array<{ title: string; contract: string; location: string; domain: string; url: string }> | null = null;
+import type { Job } from "@/../data/jobs";
+
+let mockJobs: Job[] | null = null;
 
 describe("Ta carrière with jobs", () => {
   afterEach(() => {
@@ -169,8 +171,55 @@ describe("Ta carrière with jobs", () => {
   });
 
   it("renders job cards when jobs exist", () => {
-    mockJobs = [{ title: "Dev Symfony", contract: "CDI", location: "Lille", domain: "dev", url: "/job/dev" }];
+    mockJobs = [
+      {
+        slug: "dev-symfony",
+        title: "Dev Symfony",
+        category: "CDI",
+        domain: "developpement",
+        description: "Rejoignez une équipe Symfony senior à Lille.",
+        datePosted: "2026-04-01",
+        employmentType: "FULL_TIME",
+        jobLocation: { addressLocality: "Lille", addressCountry: "FR" },
+      },
+    ];
     render(<TaCarriere />);
     expect(screen.getByText("Dev Symfony")).toBeInTheDocument();
+  });
+
+  it("emits a JobPosting JSON-LD when jobs exist", () => {
+    mockJobs = [
+      {
+        slug: "dev-symfony",
+        title: "Dev Symfony",
+        category: "CDI",
+        domain: "developpement",
+        description: "Rejoignez une équipe Symfony senior à Lille.",
+        datePosted: "2026-04-01",
+        validThrough: "2026-10-01",
+        employmentType: "FULL_TIME",
+        jobLocation: { addressLocality: "Lille", addressCountry: "FR" },
+        skills: ["Symfony", "PHP"],
+      },
+    ];
+    const { container } = render(<TaCarriere />);
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]');
+    const jobPosting = Array.from(scripts)
+      .map((s) => JSON.parse(s.innerHTML))
+      .find((json) => json["@type"] === "JobPosting");
+    expect(jobPosting).toBeDefined();
+    expect(jobPosting.title).toBe("Dev Symfony");
+    expect(jobPosting.validThrough).toBe("2026-10-01");
+    expect(jobPosting.skills).toBe("Symfony, PHP");
+  });
+
+  it("emits no JobPosting when jobs list is empty", () => {
+    mockJobs = [];
+    const { container } = render(<TaCarriere />);
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]');
+    const jobPosting = Array.from(scripts)
+      .map((s) => JSON.parse(s.innerHTML))
+      .find((json) => json["@type"] === "JobPosting");
+    expect(jobPosting).toBeUndefined();
   });
 });

--- a/src/app/ta-carriere/page.tsx
+++ b/src/app/ta-carriere/page.tsx
@@ -7,7 +7,7 @@ import { jobs, domains, spontaneousEmail } from "@/../data/jobs";
 import Link from "next/link";
 import FadeIn from "@/components/ui/FadeIn";
 import Breadcrumb from "@/components/ui/Breadcrumb";
-import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd, jobPostingJsonLd } from "@/lib/structured-data";
 import RelatedLinks from "@/components/sections/RelatedLinks";
 import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import CallToAction from "@/components/sections/CallToAction";
@@ -43,6 +43,13 @@ export default function TaCarriere() {
   return (
     <>
     <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(pageGraphJsonLd(breadcrumb, webPage)) }} />
+    {jobs.map((job) => (
+      <script
+        key={job.slug}
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jobPostingJsonLd(job)) }}
+      />
+    ))}
     <main>
       <section className="bg-light-gray py-16 md:py-24">
         <Container className="text-center">
@@ -83,7 +90,7 @@ export default function TaCarriere() {
           {jobs.length > 0 ? (
             <div className="grid gap-6 md:grid-cols-2">
               {jobs.map((job) => (
-                <JobCard key={job.title} job={job} />
+                <JobCard key={job.slug} job={job} />
               ))}
             </div>
           ) : (

--- a/src/components/cards/JobCard.tsx
+++ b/src/components/cards/JobCard.tsx
@@ -7,7 +7,7 @@ interface JobCardProps {
 
 export default function JobCard({ job }: JobCardProps) {
   return (
-    <div className="rounded-lg border border-border bg-white p-6">
+    <div id={job.slug} className="rounded-lg border border-border bg-white p-6">
       <span className="text-xs font-medium uppercase text-primary">
         {job.category}
       </span>

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,6 +1,7 @@
 import { BASE_URL, SITE_NAME } from "@/lib/metadata";
 import type { AuthorSchema } from "@/data/authors";
 import type { FaqItem, ProficiencyLevel } from "@/types/blog";
+import type { Job } from "@/../data/jobs";
 
 interface BreadcrumbItem {
   name: string;
@@ -334,5 +335,41 @@ export function eventJsonLd(event: EventSchema) {
       url: event.organizer.url,
     },
     url: event.url,
+  };
+}
+
+export function jobPostingJsonLd(job: Job) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "JobPosting",
+    title: job.title,
+    description: job.description,
+    datePosted: job.datePosted,
+    ...(job.validThrough && { validThrough: job.validThrough }),
+    employmentType: job.employmentType,
+    hiringOrganization: {
+      "@type": "Organization",
+      name: "Efficience IT",
+      sameAs: BASE_URL,
+      logo: `${BASE_URL}/images/logo/logo-og.webp`,
+    },
+    jobLocation: {
+      "@type": "Place",
+      address: {
+        "@type": "PostalAddress",
+        ...job.jobLocation,
+      },
+    },
+    ...(job.jobLocationType && { jobLocationType: job.jobLocationType }),
+    ...(job.experienceMonths !== undefined && {
+      experienceRequirements: {
+        "@type": "OccupationalExperienceRequirements",
+        monthsOfExperience: job.experienceMonths,
+      },
+    }),
+    ...(job.educationRequirements && { educationRequirements: job.educationRequirements }),
+    ...(job.skills && job.skills.length > 0 && { skills: job.skills.join(", ") }),
+    url: `${BASE_URL}/ta-carriere#${job.slug}`,
+    directApply: job.directApply ?? false,
   };
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -347,12 +347,7 @@ export function jobPostingJsonLd(job: Job) {
     datePosted: job.datePosted,
     ...(job.validThrough && { validThrough: job.validThrough }),
     employmentType: job.employmentType,
-    hiringOrganization: {
-      "@type": "Organization",
-      name: "Efficience IT",
-      sameAs: BASE_URL,
-      logo: `${BASE_URL}/images/logo/logo-og.webp`,
-    },
+    hiringOrganization: { "@id": `${BASE_URL}/#organization` },
     jobLocation: {
       "@type": "Place",
       address: {
@@ -361,15 +356,15 @@ export function jobPostingJsonLd(job: Job) {
       },
     },
     ...(job.jobLocationType && { jobLocationType: job.jobLocationType }),
-    ...(job.experienceMonths !== undefined && {
+    ...(job.experienceRequirements && {
       experienceRequirements: {
         "@type": "OccupationalExperienceRequirements",
-        monthsOfExperience: job.experienceMonths,
+        monthsOfExperience: job.experienceRequirements.monthsOfExperience,
       },
     }),
     ...(job.educationRequirements && { educationRequirements: job.educationRequirements }),
     ...(job.skills && job.skills.length > 0 && { skills: job.skills.join(", ") }),
     url: `${BASE_URL}/ta-carriere#${job.slug}`,
-    directApply: job.directApply ?? false,
+    ...(job.directApply !== undefined && { directApply: job.directApply }),
   };
 }


### PR DESCRIPTION
Closes #669

## Summary
- Interface `Job` enrichie (slug, datePosted, employmentType, jobLocation, validThrough, skills...)
- Helper `jobPostingJsonLd` dans `src/lib/structured-data.ts`
- JSON-LD émis par offre dans `/ta-carriere` (rien si tableau vide)
- Ancre `id={job.slug}` sur `JobCard`

## Validation
- Tests : 1722/1722 verts (cas vide, cas plein, champs optionnels)
- Tsc + knip clean
- Quand une offre sera ajoutée, valider via Google Rich Results Test