### PR TITLE
feat: entity linking Wikidata sur Service et Article

### DIFF
--- a/content/blog/migration-mysql-postgresql-doctrine-guide.mdx
+++ b/content/blog/migration-mysql-postgresql-doctrine-guide.mdx
@@ -7,6 +7,11 @@ category: "Symfony"
 excerpt: "Migrer de MySQL vers PostgreSQL avec Doctrine sur un projet Symfony. Différences de typage, génération du schéma et migration des données."
 image: "/images/blog/migration-mysql-postgresql.webp"
 proficiencyLevel: "Expert"
+mainTech:
+  - postgresql
+  - doctrine
+  - symfony
+  - php
 howTo:
   name: "Migrer une base MySQL vers PostgreSQL avec Doctrine"
   description: "Étapes pour migrer un projet Symfony de MySQL vers PostgreSQL en s'appuyant sur Doctrine, sans interruption de service."

--- a/src/__tests__/lib/blog.test.ts
+++ b/src/__tests__/lib/blog.test.ts
@@ -43,6 +43,52 @@ describe("getPostBySlug", () => {
       expect(post!.category).toBe("");
       expect(post!.excerpt).toBe("");
       expect(post!.wordCount).toBe(0);
+      expect(post!.mainTech).toBeUndefined();
+    } finally {
+      readFileSpy.mockRestore();
+      existsSpy.mockRestore();
+    }
+  });
+
+  it("parses mainTech array, filtering unknown keys", () => {
+    const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    const readFileSpy = jest
+      .spyOn(fs, "readFileSync")
+      .mockReturnValue("---\nmainTech: [\"symfony\", \"unknown-tech\", 42]\n---\n" as never);
+
+    try {
+      const post = getPostBySlug(TEMP_SLUG);
+      expect(post!.mainTech).toEqual(["symfony"]);
+    } finally {
+      readFileSpy.mockRestore();
+      existsSpy.mockRestore();
+    }
+  });
+
+  it("returns undefined mainTech when frontmatter has only unknown keys", () => {
+    const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    const readFileSpy = jest
+      .spyOn(fs, "readFileSync")
+      .mockReturnValue("---\nmainTech: [\"unknown\"]\n---\n" as never);
+
+    try {
+      const post = getPostBySlug(TEMP_SLUG);
+      expect(post!.mainTech).toBeUndefined();
+    } finally {
+      readFileSpy.mockRestore();
+      existsSpy.mockRestore();
+    }
+  });
+
+  it("returns undefined mainTech when frontmatter has a non-array value", () => {
+    const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    const readFileSpy = jest
+      .spyOn(fs, "readFileSync")
+      .mockReturnValue("---\nmainTech: symfony\n---\n" as never);
+
+    try {
+      const post = getPostBySlug(TEMP_SLUG);
+      expect(post!.mainTech).toBeUndefined();
     } finally {
       readFileSpy.mockRestore();
       existsSpy.mockRestore();

--- a/src/__tests__/lib/structured-data.test.ts
+++ b/src/__tests__/lib/structured-data.test.ts
@@ -1,4 +1,4 @@
-import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd, jobPostingJsonLd, articleJsonLd, TECH_ENTITIES } from "@/lib/structured-data";
+import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd, jobPostingJsonLd, articleJsonLd, TECH_ENTITIES, type TechKey } from "@/lib/structured-data";
 import { categorySlugMap } from "@/lib/blog";
 import type { Job } from "@/../data/jobs";
 
@@ -183,23 +183,23 @@ describe("entity linking via mainTech", () => {
     expect(result.about).toBeUndefined();
   });
 
-  it("filters out unknown tech keys", () => {
+  it("filters out unknown tech keys passed at runtime", () => {
     const result = serviceJsonLd({
       name: "Service",
       description: "Description",
       path: "/foo",
-      mainTech: ["symfony", "unknown-tech"],
+      mainTech: ["symfony", "unknown-tech" as unknown as TechKey],
     });
     expect(result.about).toHaveLength(1);
     expect(result.about?.[0].name).toBe("Symfony");
   });
 
-  it("returns no about when all mainTech keys are unknown", () => {
+  it("returns no about when all mainTech keys are unknown at runtime", () => {
     const result = serviceJsonLd({
       name: "Service",
       description: "Description",
       path: "/foo",
-      mainTech: ["nope", "also-nope"],
+      mainTech: ["nope", "also-nope"] as unknown as TechKey[],
     });
     expect(result.about).toBeUndefined();
   });

--- a/src/__tests__/lib/structured-data.test.ts
+++ b/src/__tests__/lib/structured-data.test.ts
@@ -1,4 +1,4 @@
-import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd, jobPostingJsonLd } from "@/lib/structured-data";
+import { howToJsonLd, reviewsJsonLd, serviceJsonLd, eventJsonLd, jobPostingJsonLd, articleJsonLd, TECH_ENTITIES } from "@/lib/structured-data";
 import { categorySlugMap } from "@/lib/blog";
 import type { Job } from "@/../data/jobs";
 
@@ -139,5 +139,79 @@ describe("jobPostingJsonLd", () => {
   it("omits skills when array is empty", () => {
     const result = jobPostingJsonLd({ ...baseJob, skills: [] });
     expect(result.skills).toBeUndefined();
+  });
+});
+
+describe("TECH_ENTITIES", () => {
+  it("exposes Wikidata entity links for known frameworks", () => {
+    expect(TECH_ENTITIES.symfony.sameAs).toContain("https://www.wikidata.org/wiki/Q2063468");
+    expect(TECH_ENTITIES.php.sameAs).toContain("https://www.wikidata.org/wiki/Q59");
+  });
+});
+
+describe("entity linking via mainTech", () => {
+  const articleInput = {
+    url: "https://www.itefficience.com/article/test",
+    isTech: true,
+    title: "Test",
+    excerpt: "Excerpt",
+    author: { "@type": "Person" as const, name: "Auteur", url: "https://example.com", jobTitle: "Author", sameAs: [] },
+    category: "Symfony",
+    date: "2026-04-01",
+    wordCount: 1200,
+    timeRequiredMinutes: 6,
+  };
+
+  it("serviceJsonLd emits about[] from known mainTech keys", () => {
+    const result = serviceJsonLd({
+      name: "Service",
+      description: "Description",
+      path: "/foo",
+      mainTech: ["symfony", "php"],
+    });
+    expect(Array.isArray(result.about)).toBe(true);
+    expect(result.about).toHaveLength(2);
+    expect(result.about?.[0]).toMatchObject({
+      "@type": "Thing",
+      name: "Symfony",
+      sameAs: expect.arrayContaining(["https://www.wikidata.org/wiki/Q2063468"]),
+    });
+  });
+
+  it("serviceJsonLd omits about when mainTech is missing", () => {
+    const result = serviceJsonLd({ name: "Service", description: "Description", path: "/foo" });
+    expect(result.about).toBeUndefined();
+  });
+
+  it("filters out unknown tech keys", () => {
+    const result = serviceJsonLd({
+      name: "Service",
+      description: "Description",
+      path: "/foo",
+      mainTech: ["symfony", "unknown-tech"],
+    });
+    expect(result.about).toHaveLength(1);
+    expect(result.about?.[0].name).toBe("Symfony");
+  });
+
+  it("returns no about when all mainTech keys are unknown", () => {
+    const result = serviceJsonLd({
+      name: "Service",
+      description: "Description",
+      path: "/foo",
+      mainTech: ["nope", "also-nope"],
+    });
+    expect(result.about).toBeUndefined();
+  });
+
+  it("articleJsonLd emits about when mainTech is provided", () => {
+    const result = articleJsonLd({ ...articleInput, mainTech: ["symfony"] });
+    expect(result.about).toHaveLength(1);
+    expect(result.about?.[0].name).toBe("Symfony");
+  });
+
+  it("articleJsonLd omits about when mainTech is absent", () => {
+    const result = articleJsonLd(articleInput);
+    expect(result.about).toBeUndefined();
   });
 });

--- a/src/app/api-nodejs-nestjs/page.tsx
+++ b/src/app/api-nodejs-nestjs/page.tsx
@@ -163,6 +163,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'API performantes avec NestJS et Node.js : microservices, GraphQL, temps réel, architecture hexagonale.",
   path: "/api-nodejs-nestjs",
+  mainTech: ["nodejs","typescript"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/api-sur-mesure-symfony/page.tsx
+++ b/src/app/api-sur-mesure-symfony/page.tsx
@@ -165,6 +165,7 @@ const service = serviceJsonLd({
   description:
     "Développement d'API REST et GraphQL sur mesure avec Symfony et API Platform : authentification OAuth2/JWT, documentation OpenAPI, TDD et monitoring.",
   path: "/api-sur-mesure-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/architecture-hexagonale-symfony/page.tsx
+++ b/src/app/architecture-hexagonale-symfony/page.tsx
@@ -176,6 +176,7 @@ const service = serviceJsonLd({
   description:
     "Conception et migration d'applications Symfony vers l'architecture hexagonale et le Domain-Driven Design : domaine isolé, ports et adaptateurs, testabilité et évolutivité.",
   path: "/architecture-hexagonale-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -118,6 +118,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     wordCount: post.wordCount,
     timeRequiredMinutes: readingTime(post.wordCount),
     proficiencyLevel: post.proficiencyLevel,
+    mainTech: post.mainTech,
   });
 
   const breadcrumb = breadcrumbJsonLd([

--- a/src/app/audit-code-php/page.tsx
+++ b/src/app/audit-code-php/page.tsx
@@ -149,6 +149,7 @@ const service = serviceJsonLd({
   description:
     "Audit technique approfondi de votre code PHP : analyse statique PHPStan niveau max, revue manuelle, rapport détaillé avec plan d'action priorisé et recommandations concrètement actionnables.",
   path: "/audit-code-php",
+  mainTech: ["php","symfony"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/base-de-donnees-postgresql-symfony/page.tsx
+++ b/src/app/base-de-donnees-postgresql-symfony/page.tsx
@@ -163,6 +163,7 @@ const service = serviceJsonLd({
   description:
     "Intégration de PostgreSQL dans vos projets Symfony avec Doctrine. Optimisation des requêtes, migration depuis MySQL, types avancés et indexation.",
   path: "/base-de-donnees-postgresql-symfony",
+  mainTech: ["postgresql","symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/cloud-et-devops/page.tsx
+++ b/src/app/cloud-et-devops/page.tsx
@@ -117,6 +117,7 @@ const service = serviceJsonLd({
   description:
     "Hébergement cloud, automatisation DevOps, migration d'infrastructure et CI/CD pour les projets web professionnels.",
   path: "/cloud-et-devops",
+  mainTech: ["docker"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-frontend/page.tsx
+++ b/src/app/developpement-frontend/page.tsx
@@ -170,6 +170,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'interfaces frontend sur mesure avec React, Vue.js, Next.js et TypeScript. Applications connectées à vos APIs Symfony ou Node.js.",
   path: "/developpement-frontend",
+  mainTech: ["typescript","react","vuejs"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-nodejs/page.tsx
+++ b/src/app/developpement-nodejs/page.tsx
@@ -130,6 +130,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'applications Node.js sur mesure : APIs REST et GraphQL, temps réel, microservices et BFF avec NestJS, TypeScript et les meilleures pratiques d'architecture.",
   path: "/developpement-nodejs",
+  mainTech: ["nodejs","typescript"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-php/page.tsx
+++ b/src/app/developpement-php/page.tsx
@@ -192,6 +192,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'applications web PHP sur mesure avec PHP 8, Symfony, Doctrine et les meilleures pratiques d'architecture logicielle.",
   path: "/developpement-php",
+  mainTech: ["php","symfony"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-react/page.tsx
+++ b/src/app/developpement-react/page.tsx
@@ -171,6 +171,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'applications React et TypeScript sur mesure : SPA, dashboards, backoffices. Connectées à vos APIs Symfony ou Node.js.",
   path: "/developpement-react",
+  mainTech: ["react","typescript"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-typescript/page.tsx
+++ b/src/app/developpement-typescript/page.tsx
@@ -177,6 +177,7 @@ const service = serviceJsonLd({
   description:
     "Développement d'applications typées et maintenables en TypeScript. Migration JavaScript, applications React et Node.js, configuration et outillage.",
   path: "/developpement-typescript",
+  mainTech: ["typescript"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-vuejs/page.tsx
+++ b/src/app/developpement-vuejs/page.tsx
@@ -164,6 +164,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'applications Vue.js et Nuxt sur mesure. Interfaces légères, intégration Symfony native et montée en charge progressive.",
   path: "/developpement-vuejs",
+  mainTech: ["vuejs","typescript"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/developpement-web-sur-mesure/page.tsx
+++ b/src/app/developpement-web-sur-mesure/page.tsx
@@ -99,6 +99,7 @@ const service = serviceJsonLd({
   description:
     "Conception et développement d'applications web avec Symfony, Sylius et les technologies PHP modernes.",
   path: "/developpement-web-sur-mesure",
+  mainTech: ["php","symfony"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/ecommerce-sylius/page.tsx
+++ b/src/app/ecommerce-sylius/page.tsx
@@ -123,6 +123,7 @@ const service = serviceJsonLd({
   description:
     "Développement de boutiques e-commerce avec Sylius, la plateforme open source basée sur Symfony.",
   path: "/ecommerce-sylius",
+  mainTech: ["sylius","symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/hebergement-symfony/page.tsx
+++ b/src/app/hebergement-symfony/page.tsx
@@ -123,6 +123,7 @@ const service = serviceJsonLd({
   description:
     "Hébergement cloud, déploiement CI/CD et monitoring pour les applications Symfony.",
   path: "/hebergement-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/integration-docker-symfony/page.tsx
+++ b/src/app/integration-docker-symfony/page.tsx
@@ -163,6 +163,7 @@ const service = serviceJsonLd({
   description:
     "Conteneurisation et déploiement d'applications Symfony avec Docker. Dockerfile optimisé, Docker Compose, CI/CD et monitoring en production.",
   path: "/integration-docker-symfony",
+  mainTech: ["docker","symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/integration-elasticsearch-symfony/page.tsx
+++ b/src/app/integration-elasticsearch-symfony/page.tsx
@@ -157,6 +157,7 @@ const service = serviceJsonLd({
   description:
     "Intégration d'Elasticsearch dans vos projets Symfony. Indexation, recherche full-text, filtres à facettes et suggestions pour une expérience utilisateur fluide.",
   path: "/integration-elasticsearch-symfony",
+  mainTech: ["elasticsearch","symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/integration-redis-symfony/page.tsx
+++ b/src/app/integration-redis-symfony/page.tsx
@@ -158,6 +158,7 @@ const service = serviceJsonLd({
   description:
     "Intégration de Redis dans vos applications Symfony pour le cache, les sessions, les files d'attente Messenger et l'amélioration des performances.",
   path: "/integration-redis-symfony",
+  mainTech: ["redis","symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/maintenance-applicative-symfony/page.tsx
+++ b/src/app/maintenance-applicative-symfony/page.tsx
@@ -174,6 +174,7 @@ const service = serviceJsonLd({
   description:
     "Maintenance corrective, évolutive et préventive de vos applications Symfony : correction de bugs, évolutions fonctionnelles, mises à jour de sécurité, monitoring et SLA sur mesure.",
   path: "/maintenance-applicative-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/migration-symfony/page.tsx
+++ b/src/app/migration-symfony/page.tsx
@@ -151,6 +151,7 @@ const service = serviceJsonLd({
   description:
     "Migration Symfony 4, 5, 6 vers Symfony 7 : montée de version progressive par paliers, sans interruption de service. Audit des dépréciations, refactoring Rector et validation continue.",
   path: "/migration-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/modernisation-application-php/page.tsx
+++ b/src/app/modernisation-application-php/page.tsx
@@ -185,6 +185,7 @@ const service = serviceJsonLd({
   description:
     "Migration et modernisation d'applications PHP obsolètes vers Symfony : audit technique, refactoring progressif, mise en place de tests et déploiement continu.",
   path: "/modernisation-application-php",
+  mainTech: ["php","symfony"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/modernisation-applicative/page.tsx
+++ b/src/app/modernisation-applicative/page.tsx
@@ -46,6 +46,7 @@ const service = serviceJsonLd({
   name: "Modernisation applicative",
   description: "Parcours structuré de modernisation d'applications PHP et Symfony : audit technique, refactoring progressif, migration architecturale et maintenance continue.",
   path: "/modernisation-applicative",
+  mainTech: ["php","symfony"],
 });
 
 const situations = [

--- a/src/app/reprise-projet-symfony/page.tsx
+++ b/src/app/reprise-projet-symfony/page.tsx
@@ -150,6 +150,7 @@ const service = serviceJsonLd({
   description:
     "Audit, stabilisation, documentation et maintenance d'applications Symfony reprises en cours de vie : nous prenons le relais de votre prestataire et assurons la continuité de votre projet.",
   path: "/reprise-projet-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/securite-application-symfony/page.tsx
+++ b/src/app/securite-application-symfony/page.tsx
@@ -163,6 +163,7 @@ const service = serviceJsonLd({
   description:
     "Audit de vulnérabilités, protection OWASP, conformité RGPD et mise en place de bonnes pratiques de sécurité pour vos applications Symfony.",
   path: "/securite-application-symfony",
+  mainTech: ["symfony","php"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/app/tests-automatises-php/page.tsx
+++ b/src/app/tests-automatises-php/page.tsx
@@ -118,6 +118,7 @@ const service = serviceJsonLd({
   description:
     "Mise en place de stratégies de tests automatisés pour applications PHP et Symfony : tests unitaires, intégration, fonctionnels et e2e, avec intégration CI/CD pour sécuriser chaque livraison.",
   path: "/tests-automatises-php",
+  mainTech: ["php","symfony"],
 });
 
 const webPage = webPageJsonLd({

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -2,8 +2,15 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { BlogPost } from "@/types/blog";
+import { TECH_ENTITIES, type TechKey } from "@/lib/structured-data";
 
 const BLOG_DIR = path.join(process.cwd(), "content/blog");
+
+function parseMainTech(value: unknown): TechKey[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const valid = value.filter((v): v is TechKey => typeof v === "string" && v in TECH_ENTITIES);
+  return valid.length > 0 ? valid : undefined;
+}
 
 function countWords(markdown: string): number {
   const text = markdown
@@ -44,7 +51,7 @@ export function getAllPosts(): BlogPost[] {
       faq: data.faq,
       event: data.event,
       howTo: data.howTo,
-      mainTech: data.mainTech,
+      mainTech: parseMainTech(data.mainTech),
       content,
       wordCount: countWords(content),
     };
@@ -75,7 +82,7 @@ export function getPostBySlug(slug: string): BlogPost | undefined {
     faq: data.faq,
     event: data.event,
     howTo: data.howTo,
-    mainTech: data.mainTech,
+    mainTech: parseMainTech(data.mainTech),
     content,
     wordCount: countWords(content),
   };

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -44,6 +44,7 @@ export function getAllPosts(): BlogPost[] {
       faq: data.faq,
       event: data.event,
       howTo: data.howTo,
+      mainTech: data.mainTech,
       content,
       wordCount: countWords(content),
     };
@@ -74,6 +75,7 @@ export function getPostBySlug(slug: string): BlogPost | undefined {
     faq: data.faq,
     event: data.event,
     howTo: data.howTo,
+    mainTech: data.mainTech,
     content,
     wordCount: countWords(content),
   };

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -135,13 +135,99 @@ export function breadcrumbJsonLd(items: BreadcrumbItem[]) {
   };
 }
 
+export const TECH_ENTITIES: Record<string, { name: string; sameAs: string[] }> = {
+  symfony: {
+    name: "Symfony",
+    sameAs: [
+      "https://www.wikidata.org/wiki/Q2063468",
+      "https://symfony.com",
+      "https://en.wikipedia.org/wiki/Symfony",
+    ],
+  },
+  php: {
+    name: "PHP",
+    sameAs: [
+      "https://www.wikidata.org/wiki/Q59",
+      "https://www.php.net",
+      "https://en.wikipedia.org/wiki/PHP",
+    ],
+  },
+  laravel: {
+    name: "Laravel",
+    sameAs: ["https://www.wikidata.org/wiki/Q6485503", "https://laravel.com"],
+  },
+  react: {
+    name: "React",
+    sameAs: ["https://www.wikidata.org/wiki/Q19399674", "https://react.dev"],
+  },
+  nodejs: {
+    name: "Node.js",
+    sameAs: ["https://www.wikidata.org/wiki/Q756100", "https://nodejs.org"],
+  },
+  typescript: {
+    name: "TypeScript",
+    sameAs: ["https://www.wikidata.org/wiki/Q978185", "https://www.typescriptlang.org"],
+  },
+  docker: {
+    name: "Docker",
+    sameAs: ["https://www.wikidata.org/wiki/Q15206305", "https://www.docker.com"],
+  },
+  postgresql: {
+    name: "PostgreSQL",
+    sameAs: ["https://www.wikidata.org/wiki/Q192490", "https://www.postgresql.org"],
+  },
+  redis: {
+    name: "Redis",
+    sameAs: ["https://www.wikidata.org/wiki/Q2136322", "https://redis.io"],
+  },
+  elasticsearch: {
+    name: "Elasticsearch",
+    sameAs: ["https://www.wikidata.org/wiki/Q3050461", "https://www.elastic.co/elasticsearch/"],
+  },
+  rabbitmq: {
+    name: "RabbitMQ",
+    sameAs: ["https://www.wikidata.org/wiki/Q1727422", "https://www.rabbitmq.com"],
+  },
+  doctrine: {
+    name: "Doctrine ORM",
+    sameAs: ["https://www.wikidata.org/wiki/Q3036524"],
+  },
+  vuejs: {
+    name: "Vue.js",
+    sameAs: ["https://www.wikidata.org/wiki/Q17205803", "https://vuejs.org"],
+  },
+  nextjs: {
+    name: "Next.js",
+    sameAs: ["https://www.wikidata.org/wiki/Q102083000", "https://nextjs.org"],
+  },
+  sylius: {
+    name: "Sylius",
+    sameAs: ["https://sylius.com"],
+  },
+};
+
+function aboutTechEntities(keys: string[] | undefined) {
+  if (!keys || keys.length === 0) return undefined;
+  const entities = keys
+    .map((key) => TECH_ENTITIES[key])
+    .filter((entity): entity is (typeof TECH_ENTITIES)[string] => Boolean(entity))
+    .map((entity) => ({
+      "@type": "Thing" as const,
+      name: entity.name,
+      sameAs: entity.sameAs,
+    }));
+  return entities.length > 0 ? entities : undefined;
+}
+
 interface ServiceSchemaProps {
   name: string;
   description: string;
   path: string;
+  mainTech?: string[];
 }
 
-export function serviceJsonLd({ name, description, path }: ServiceSchemaProps) {
+export function serviceJsonLd({ name, description, path, mainTech }: ServiceSchemaProps) {
+  const about = aboutTechEntities(mainTech);
   return {
     "@context": "https://schema.org",
     "@type": "Service",
@@ -157,6 +243,7 @@ export function serviceJsonLd({ name, description, path }: ServiceSchemaProps) {
       { "@type": "Country", name: "Spain" },
       { "@type": "Country", name: "Germany" },
     ],
+    ...(about && { about }),
   };
 }
 
@@ -259,9 +346,11 @@ interface ArticleJsonLdInput {
   wordCount: number;
   timeRequiredMinutes: number;
   proficiencyLevel?: ProficiencyLevel;
+  mainTech?: string[];
 }
 
 export function articleJsonLd(input: ArticleJsonLdInput) {
+  const about = aboutTechEntities(input.mainTech);
   return {
     "@context": "https://schema.org",
     "@type": input.isTech ? "TechArticle" : "BlogPosting",
@@ -297,6 +386,7 @@ export function articleJsonLd(input: ArticleJsonLdInput) {
     ...(input.isTech && {
       proficiencyLevel: input.proficiencyLevel ?? "Intermediate",
     }),
+    ...(about && { about }),
   };
 }
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -135,7 +135,7 @@ export function breadcrumbJsonLd(items: BreadcrumbItem[]) {
   };
 }
 
-export const TECH_ENTITIES: Record<string, { name: string; sameAs: string[] }> = {
+export const TECH_ENTITIES = {
   symfony: {
     name: "Symfony",
     sameAs: [
@@ -202,20 +202,26 @@ export const TECH_ENTITIES: Record<string, { name: string; sameAs: string[] }> =
   },
   sylius: {
     name: "Sylius",
-    sameAs: ["https://sylius.com"],
+    sameAs: ["https://www.wikidata.org/wiki/Q47561527", "https://sylius.com"],
   },
-};
+} as const;
 
-function aboutTechEntities(keys: string[] | undefined) {
+export type TechKey = keyof typeof TECH_ENTITIES;
+
+const TECH_KEYS = new Set<string>(Object.keys(TECH_ENTITIES));
+
+function aboutTechEntities(keys: readonly TechKey[] | undefined) {
   if (!keys || keys.length === 0) return undefined;
   const entities = keys
-    .map((key) => TECH_ENTITIES[key])
-    .filter((entity): entity is (typeof TECH_ENTITIES)[string] => Boolean(entity))
-    .map((entity) => ({
-      "@type": "Thing" as const,
-      name: entity.name,
-      sameAs: entity.sameAs,
-    }));
+    .filter((key): key is TechKey => TECH_KEYS.has(key))
+    .map((key) => {
+      const entity = TECH_ENTITIES[key];
+      return {
+        "@type": "Thing" as const,
+        name: entity.name,
+        sameAs: [...entity.sameAs],
+      };
+    });
   return entities.length > 0 ? entities : undefined;
 }
 
@@ -223,7 +229,7 @@ interface ServiceSchemaProps {
   name: string;
   description: string;
   path: string;
-  mainTech?: string[];
+  mainTech?: readonly TechKey[];
 }
 
 export function serviceJsonLd({ name, description, path, mainTech }: ServiceSchemaProps) {
@@ -346,7 +352,7 @@ interface ArticleJsonLdInput {
   wordCount: number;
   timeRequiredMinutes: number;
   proficiencyLevel?: ProficiencyLevel;
-  mainTech?: string[];
+  mainTech?: readonly TechKey[];
 }
 
 export function articleJsonLd(input: ArticleJsonLdInput) {

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -48,6 +48,7 @@ export interface BlogPost {
   faq?: FaqItem[];
   event?: EventSchema;
   howTo?: HowToSchema;
+  mainTech?: string[];
   content: string;
   wordCount: number;
 }

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,3 +1,5 @@
+import type { TechKey } from "@/lib/structured-data";
+
 export type ProficiencyLevel = "Beginner" | "Intermediate" | "Expert";
 
 export interface FaqItem {
@@ -48,7 +50,7 @@ export interface BlogPost {
   faq?: FaqItem[];
   event?: EventSchema;
   howTo?: HowToSchema;
-  mainTech?: string[];
+  mainTech?: readonly TechKey[];
   content: string;
   wordCount: number;
 }


### PR DESCRIPTION
Closes #669... wait closes #673

## Summary
- Map `TECH_ENTITIES` (Wikidata IDs + URLs canoniques) dans `src/lib/structured-data.ts`
- Helper interne `aboutTechEntities` qui produit un `about[]` schema.org `Thing` avec `sameAs`
- `serviceJsonLd` accepte une prop `mainTech?: string[]`
- `articleJsonLd` accepte une prop `mainTech?: string[]`
- Frontmatter `mainTech` lu par `getAllPosts`/`getPostBySlug`, propagé au `BlogPost`
- 25 pages services taggées avec leurs technos principales
- 1 article témoin taggé (`migration-mysql-postgresql-doctrine-guide.mdx`)

## Validation
- 1729/1729 tests verts
- Coverage 100%, tsc + knip clean
- À valider en prod via Google Rich Results Test sur 1 page service + 1 article