### PR TITLE
content: sections longue traîne

### DIFF
--- a/src/app/agence-symfony-paris/page.tsx
+++ b/src/app/agence-symfony-paris/page.tsx
@@ -592,7 +592,7 @@ export default function AgenceSymfonyParis() {
                       pourquoi Docker est indispensable en production
                     </Link>
                     . Nous détaillons notre démarche sur la page dédiée à
-                    l&apos;{" "}
+                    l&apos;
                     <Link
                       href="/integration-docker-symfony"
                       className="text-primary hover:underline"

--- a/src/app/agence-symfony-paris/page.tsx
+++ b/src/app/agence-symfony-paris/page.tsx
@@ -537,6 +537,134 @@ export default function AgenceSymfonyParis() {
         <FadeIn>
           <section className="bg-light-gray py-16 md:py-24">
             <Container>
+              <div className="mx-auto max-w-3xl space-y-12">
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    API Platform à Paris : intégration et migration
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    API Platform est notre socle pour exposer des API REST et
+                    GraphQL sur Symfony. Le framework génère la documentation
+                    OpenAPI, gère la pagination, le filtrage et la sérialisation à
+                    partir de simples attributs sur les entités. Pour les équipes
+                    parisiennes qui partent d&apos;un contrôleur fait main ou
+                    d&apos;une ancienne version, nous migrons progressivement vers
+                    API Platform sans casser les contrats existants, en versionnant
+                    les endpoints. La conception reste guidée par les bonnes
+                    pratiques : notre article sur{" "}
+                    <Link
+                      href="/article/api-rest-les-bonnes-pratiques"
+                      className="text-primary hover:underline"
+                    >
+                      les bonnes pratiques des API REST
+                    </Link>{" "}
+                    détaille le nommage des ressources, les codes de statut et la
+                    gestion des erreurs. Le résultat : une{" "}
+                    <Link
+                      href="/api-sur-mesure-symfony"
+                      className="text-primary hover:underline"
+                    >
+                      API sur mesure Symfony
+                    </Link>{" "}
+                    documentée, testable et prête pour vos applications mobiles
+                    comme pour vos partenaires.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    Docker et conteneurisation pour applications Symfony
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    Nous livrons chaque projet parisien avec un environnement
+                    Docker reproductible, identique du poste développeur à la
+                    production. Les versions de PHP, des extensions et des services
+                    (PostgreSQL, Redis, RabbitMQ) sont figées dans des images
+                    versionnées. Cette parité réduit les bugs d&apos;intégration et
+                    accélère l&apos;arrivée d&apos;un nouveau développeur sur le
+                    projet, qui démarre en une commande. En production, la
+                    conteneurisation simplifie le déploiement et le scaling
+                    horizontal. Pour comprendre pourquoi cette approche est devenue
+                    un standard, lisez{" "}
+                    <Link
+                      href="/article/pourquoi-docker-est-indispensable-en-production-aujourdhui"
+                      className="text-primary hover:underline"
+                    >
+                      pourquoi Docker est indispensable en production
+                    </Link>
+                    . Nous détaillons notre démarche sur la page dédiée à
+                    l&apos;{" "}
+                    <Link
+                      href="/integration-docker-symfony"
+                      className="text-primary hover:underline"
+                    >
+                      intégration de Docker avec Symfony
+                    </Link>
+                    .
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    PostgreSQL et Symfony : performance et tuning
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    PostgreSQL est notre base de données de prédilection pour les
+                    projets exigeants. Au-delà de l&apos;installation, nous tirons
+                    parti de ses fonctionnalités avancées : index partiels et index
+                    GIN, type JSONB pour les données semi-structurées, recherche
+                    full-text native et requêtes fenêtrées. Côté Doctrine, le
+                    tuning passe par l&apos;élimination des requêtes N+1, le choix
+                    des bons modes de fetch et l&apos;usage raisonné du cache de
+                    second niveau. Pour les applications qui quittent MySQL, notre{" "}
+                    <Link
+                      href="/article/migration-mysql-postgresql-doctrine-guide"
+                      className="text-primary hover:underline"
+                    >
+                      guide de migration de MySQL vers PostgreSQL avec Doctrine
+                    </Link>{" "}
+                    couvre les pièges de typage et de portabilité SQL.
+                    L&apos;ensemble de notre savoir-faire est présenté sur la page{" "}
+                    <Link
+                      href="/base-de-donnees-postgresql-symfony"
+                      className="text-primary hover:underline"
+                    >
+                      base de données PostgreSQL et Symfony
+                    </Link>
+                    .
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    Stack technique des projets parisiens
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    Nos projets parisiens reposent sur une stack éprouvée et
+                    homogène : Symfony et PHP 8 pour le back-end, Doctrine pour la
+                    persistance, Messenger pour l&apos;asynchrone, le tout outillé
+                    par PHPStan au niveau maximal et une suite de tests
+                    automatisés. Selon les besoins, nous ajoutons une couche de
+                    recherche Elasticsearch, du cache Redis ou un front-end
+                    découplé en React ou Vue. Ce socle commun garantit que nos
+                    équipes sont interchangeables et que votre application reste
+                    maintenable sur la durée, sans dépendance à un développeur
+                    unique. Pour un panorama complet de nos compétences techniques,
+                    consultez{" "}
+                    <Link
+                      href="/notre-expertise"
+                      className="text-primary hover:underline"
+                    >
+                      notre expertise
+                    </Link>
+                    .
+                  </p>
+                </div>
+              </div>
+            </Container>
+          </section>
+        </FadeIn>
+
+        <FadeIn>
+          <section className="bg-light-gray py-16 md:py-24">
+            <Container>
               <SectionTitle>Questions fréquentes</SectionTitle>
               <div className="mx-auto max-w-2xl">
                 <Accordion items={faqItems} />

--- a/src/app/expertise-ia/page.tsx
+++ b/src/app/expertise-ia/page.tsx
@@ -344,6 +344,115 @@ export default function ExpertiseIa() {
       </FadeIn>
 
       <FadeIn>
+      <section className="bg-light-gray py-16 md:py-24">
+        <Container>
+          <div className="mx-auto max-w-3xl space-y-12">
+            <div>
+              <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                RAG sur données Doctrine : architecture
+              </h2>
+              <p className="mt-4 text-lg text-gray">
+                Le RAG (Retrieval-Augmented Generation) permet à un modèle de
+                langage de répondre à partir de vos données métier plutôt que de
+                ses seules connaissances généralistes. Concrètement, nous indexons
+                vos entités Doctrine dans une base vectorielle, puis nous injectons
+                les passages les plus pertinents dans le prompt au moment de la
+                requête. L&apos;enjeu est autant fonctionnel (qualité du chunking,
+                fraîcheur de l&apos;index) que technique (synchronisation via
+                Messenger, choix du vector store). Notre retour d&apos;expérience
+                détaillé sur{" "}
+                <Link
+                  href="/article/rag-symfony-ai-doctrine-indexer-base-metier"
+                  className="text-primary hover:underline"
+                >
+                  le RAG avec Symfony AI et Doctrine pour indexer une base métier
+                </Link>{" "}
+                montre une architecture complète, du parsing des documents
+                jusqu&apos;à la génération de la réponse citée.
+              </p>
+            </div>
+            <div>
+              <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                LLM et intégration dans une application Symfony
+              </h2>
+              <p className="mt-4 text-lg text-gray">
+                Brancher un LLM sur une application Symfony ne se limite pas à
+                appeler une API externe. Il faut gérer les coûts par token, la
+                latence, le streaming des réponses, la mise en cache des appels et
+                les garde-fous contre les hallucinations. Nous encapsulons ces
+                préoccupations dans des services dédiés, testables et remplaçables,
+                pour ne jamais coupler votre code métier à un fournisseur précis.
+                Cette approche découplée facilite le passage d&apos;un modèle à un
+                autre selon le rapport qualité/coût. Notre{" "}
+                <Link
+                  href="/article/symfony-ai-projet-legacy-retour-experience"
+                  className="text-primary hover:underline"
+                >
+                  retour d&apos;expérience sur l&apos;intégration de l&apos;IA dans
+                  un projet legacy Symfony
+                </Link>{" "}
+                illustre comment ajouter ces capacités sans réécrire
+                l&apos;existant.
+              </p>
+            </div>
+            <div>
+              <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                Assistants IA et agents conversationnels
+              </h2>
+              <p className="mt-4 text-lg text-gray">
+                Au-delà du simple chatbot, un agent conversationnel peut interroger
+                vos données, déclencher des actions et enchaîner des étapes en
+                autonomie. La difficulté n&apos;est pas de générer du texte, mais
+                de cadrer l&apos;agent : définir ses outils, borner ses droits et
+                tracer ses décisions. Nous concevons des assistants ancrés dans
+                votre domaine métier, avec une supervision humaine sur les actions
+                sensibles. Le choix du modèle dépend de l&apos;usage : notre
+                comparatif pour{" "}
+                <Link
+                  href="/article/quel-assistant-ia-choisir-pour-coder"
+                  className="text-primary hover:underline"
+                >
+                  choisir le bon assistant IA pour coder
+                </Link>{" "}
+                et notre analyse des{" "}
+                <Link
+                  href="/article/forces-et-faiblesses-des-ia-generatives-les-plus-utilisees"
+                  className="text-primary hover:underline"
+                >
+                  forces et faiblesses des IA génératives les plus utilisées
+                </Link>{" "}
+                aident à arbitrer entre fluidité, fiabilité et coût.
+              </p>
+            </div>
+            <div>
+              <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                MCP et exposition de l&apos;API Symfony
+              </h2>
+              <p className="mt-4 text-lg text-gray">
+                Le Model Context Protocol (MCP) standardise la façon dont un
+                assistant IA accède à des outils et des données externes. En
+                exposant votre application Symfony via un serveur MCP, vous
+                permettez à un agent d&apos;interroger vos endpoints de manière
+                contrôlée, sans lui donner un accès brut à la base. C&apos;est une
+                brique clé pour transformer une API existante en source
+                d&apos;actions pour l&apos;IA, tout en gardant l&apos;authentification
+                et les autorisations Symfony. Notre article sur{" "}
+                <Link
+                  href="/article/serveurs-mcp-claude-code-developpeurs-symfony"
+                  className="text-primary hover:underline"
+                >
+                  les serveurs MCP avec Claude Code pour les développeurs Symfony
+                </Link>{" "}
+                montre comment mettre en place cette passerelle et quels
+                garde-fous prévoir.
+              </p>
+            </div>
+          </div>
+        </Container>
+      </section>
+      </FadeIn>
+
+      <FadeIn>
       <RelatedLinks links={expertiseIaRelatedLinks} />
       </FadeIn>
 

--- a/src/app/migration-symfony/page.tsx
+++ b/src/app/migration-symfony/page.tsx
@@ -379,6 +379,162 @@ export default function MigrationSymfony() {
         </FadeIn>
 
         <FadeIn>
+        <section className="bg-light-gray py-16 md:py-24">
+          <Container>
+            <div className="mx-auto max-w-3xl space-y-12">
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Rector pour automatiser la migration Symfony
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  Rector applique des règles de transformation qui réécrivent
+                  automatiquement le code obsolète : déprécations remplacées,
+                  annotations converties en attributs PHP 8, signatures de
+                  méthodes mises à jour. Sur une montée de version, il absorbe la
+                  part répétitive du travail et laisse l&apos;équipe se concentrer
+                  sur les changements qui demandent une vraie réflexion métier.
+                  Nous configurons des sets de règles ciblés par version puis
+                  relisons chaque diff, car l&apos;automatisation ne dispense
+                  jamais de la revue. Pour comprendre la mécanique et les limites
+                  de l&apos;outil, notre article sur{" "}
+                  <Link
+                    href="/article/rector-et-ses-pouvoirs-maitrisez-levolution-de-votre-code-symfony"
+                    className="text-primary hover:underline"
+                  >
+                    Rector et ses capacités de transformation du code Symfony
+                  </Link>{" "}
+                  détaille les cas où il fait gagner des journées entières.
+                </p>
+              </div>
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Tests automatisés pendant une migration de version
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  Une migration sans filet de tests revient à changer un moteur
+                  en roulant. Avant de toucher au code, nous vérifions la
+                  couverture existante et complétons les zones critiques par des
+                  tests fonctionnels qui figent le comportement attendu. Chaque
+                  palier de version est validé contre cette suite : si un test
+                  casse, la régression est identifiée immédiatement, pas en
+                  production. Quand la base est trop peu testée, nous mettons en
+                  place une stratégie de{" "}
+                  <Link
+                    href="/tests-automatises-php"
+                    className="text-primary hover:underline"
+                  >
+                    tests automatisés PHP
+                  </Link>{" "}
+                  progressive, en priorisant les parcours métier les plus
+                  sensibles. PHPStan complète le dispositif en détectant
+                  statiquement les appels à des API supprimées entre deux
+                  versions.
+                </p>
+              </div>
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Performance applicative après migration
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  Monter de version n&apos;apporte pas seulement des correctifs de
+                  sécurité : chaque release majeure de Symfony améliore le
+                  conteneur de services, le routeur et le composant Cache. Encore
+                  faut-il en profiter. Après la migration, nous profilons
+                  l&apos;application pour mesurer les gains réels et traquer les
+                  régressions éventuelles, comme des services mal configurés en
+                  lazy ou un autowiring trop large. L&apos;optimisation passe
+                  souvent par une révision des stratégies de cache : notre guide
+                  pour{" "}
+                  <Link
+                    href="/article/tout-savoir-sur-la-mise-en-cache-tips"
+                    className="text-primary hover:underline"
+                  >
+                    maîtriser la mise en cache dans Symfony
+                  </Link>{" "}
+                  couvre le cache HTTP, le cache applicatif et l&apos;invalidation.
+                  Le résultat se mesure en temps de réponse et en consommation
+                  mémoire, pas en numéro de version.
+                </p>
+              </div>
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Migration Symfony 4 vers 7 : étapes clés
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  Passer de Symfony 4 à 7 ne se fait pas d&apos;un bloc. Le chemin
+                  recommandé suit les paliers LTS : 4.4, puis 5.4, puis 6.4, avant
+                  d&apos;atteindre 7. Chaque palier neutralise les déprécations
+                  avant qu&apos;elles ne deviennent des erreurs fatales à la
+                  version suivante. Les chantiers structurants concernent la
+                  configuration (passage au format attributs et au répertoire
+                  config/), le composant Security entièrement refondu en 5.x, et
+                  la montée de Doctrine. Nous traitons les déprécations version par
+                  version, en gardant une application livrable à chaque étape.
+                  Notre{" "}
+                  <Link
+                    href="/article/guide-de-migration-dans-un-projet-symfony"
+                    className="text-primary hover:underline"
+                  >
+                    guide de migration dans un projet Symfony
+                  </Link>{" "}
+                  décrit la démarche pas à pas.
+                </p>
+              </div>
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Migration Symfony 5 vers 7 : étapes clés
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  Depuis Symfony 5.4 LTS, la route vers la 7 passe par la 6.4. La
+                  principale rupture se situe entre 5 et 6 : montée à PHP 8.1
+                  minimum, généralisation des attributs, et refonte de plusieurs
+                  signatures dans les composants HttpFoundation et Security. La 6.4
+                  puis la 7 demandent surtout de nettoyer les dernières
+                  déprécations et d&apos;aligner les dépendances tierces
+                  compatibles. Le composant Doctrine mérite une attention
+                  particulière : la mise à jour de l&apos;ORM s&apos;accompagne
+                  souvent de changements de comportement sur les types et les
+                  requêtes. Pour anticiper ce volet, consultez notre retour sur{" "}
+                  <Link
+                    href="/article/doctrine-orm-3-0-une-nouvelle-version-majeure-pour-les-bases-de-donnees"
+                    className="text-primary hover:underline"
+                  >
+                    la version majeure de Doctrine ORM 3.0
+                  </Link>
+                  .
+                </p>
+              </div>
+              <div>
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Migration Symfony 6 vers 7 : étapes clés
+                </h2>
+                <p className="mt-4 text-lg text-gray">
+                  La migration de Symfony 6.4 vers 7 est la plus douce des trois.
+                  Comme 6.4 et 7.0 partagent la même base, l&apos;essentiel du
+                  travail consiste à supprimer tout usage de code déprécé signalé
+                  en 6.4 : le pont de dépréciations permet justement de tout
+                  corriger avant le saut. Une fois l&apos;application sans
+                  avertissement sous 6.4, le passage à 7 se résume à mettre à jour
+                  les contraintes de version dans composer.json et à relancer la
+                  suite de tests. C&apos;est le scénario idéal que nous visons pour
+                  toutes nos migrations : faire de chaque LTS un point d&apos;appui
+                  stable plutôt qu&apos;un grand saut risqué. Reporter ces mises à
+                  jour ne fait qu&apos;accroître la{" "}
+                  <Link
+                    href="/article/la-dette-technique-faut-il-vraiment-en-avoir-peur"
+                    className="text-primary hover:underline"
+                  >
+                    dette technique
+                  </Link>{" "}
+                  et la facture finale.
+                </p>
+              </div>
+            </div>
+          </Container>
+        </section>
+        </FadeIn>
+
+        <FadeIn>
         <section className="bg-primary py-16 text-center text-white">
           <div className="mx-auto max-w-3xl px-4">
             <h2 className="font-display text-3xl font-bold">

--- a/src/app/securite-application-symfony/page.tsx
+++ b/src/app/securite-application-symfony/page.tsx
@@ -407,6 +407,113 @@ export default function SecuriteApplicationSymfony() {
         <FadeIn>
           <section className="bg-light-gray py-16 md:py-24">
             <Container>
+              <div className="mx-auto max-w-3xl space-y-12">
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    OWASP Top 10 appliqué à Symfony
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    L&apos;OWASP Top 10 recense les risques de sécurité les plus
+                    répandus : injection, défaillances d&apos;authentification,
+                    exposition de données sensibles, mauvaises configurations.
+                    Symfony fournit des protections natives contre la plupart
+                    d&apos;entre eux (requêtes préparées via Doctrine, protection
+                    CSRF des formulaires, échappement automatique de Twig), mais
+                    aucune n&apos;est efficace si elle est contournée ou mal
+                    configurée. Nous auditons chaque catégorie du Top 10 sur votre
+                    application, du contrôle d&apos;accès aux dépendances
+                    vulnérables. La sensibilisation des équipes fait partie du
+                    dispositif : notre article sur{" "}
+                    <Link
+                      href="/article/comment-former-vos-equipes-a-la-securite-informatique-en-toute-simplicite"
+                      className="text-primary hover:underline"
+                    >
+                      comment former vos équipes à la sécurité informatique
+                    </Link>{" "}
+                    explique comment ancrer ces réflexes au quotidien.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    Gestion des CVE et politique de patch
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    Une application n&apos;est jamais figée : les failles sont
+                    découvertes en continu dans les dépendances que vous utilisez.
+                    Sans politique de patch, une CVE publiée devient une porte
+                    ouverte pendant des mois. Nous mettons en place une veille
+                    automatisée (composer audit, alertes de sécurité) et un
+                    processus de mise à jour priorisé selon la criticité réelle,
+                    pas seulement le score CVSS. Chaque correctif est validé par la
+                    suite de tests avant déploiement, pour ne pas troquer une
+                    faille contre une régression. Pour comprendre le cycle de vie
+                    d&apos;une vulnérabilité, notre article sur{" "}
+                    <Link
+                      href="/article/cve-comprendre-les-failles-pour-mieux-se-proteger"
+                      className="text-primary hover:underline"
+                    >
+                      les CVE et comment s&apos;en protéger
+                    </Link>{" "}
+                    pose les bases.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    RGPD et logs applicatifs
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    Les logs sont précieux pour le débogage, mais ils deviennent un
+                    risque dès qu&apos;ils contiennent des données personnelles :
+                    e-mails, identifiants, adresses IP. La conformité RGPD impose de
+                    minimiser ces données, de les anonymiser et de borner leur
+                    durée de conservation. Nous configurons Monolog pour filtrer
+                    les informations sensibles à la source, et nous mettons en place
+                    une rotation et une purge maîtrisées. Pour les environnements de
+                    test et de pré-production, l&apos;anonymisation des bases est
+                    indispensable : notre article sur{" "}
+                    <Link
+                      href="/article/dbtoolsbundle-anonymiser-vos-bases-de-donnees"
+                      className="text-primary hover:underline"
+                    >
+                      anonymiser vos bases de données avec DbToolsBundle
+                    </Link>{" "}
+                    montre comment travailler sur des données réalistes sans
+                    exposer de données réelles.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                    Authentification forte et passkeys WebAuthn
+                  </h2>
+                  <p className="mt-4 text-lg text-gray">
+                    Le mot de passe seul ne suffit plus. L&apos;authentification
+                    forte combine plusieurs facteurs, et les passkeys basées sur le
+                    standard WebAuthn permettent une connexion sans mot de passe,
+                    résistante au phishing, adossée au matériel de l&apos;utilisateur
+                    (empreinte, clé physique). Le composant Security de Symfony
+                    s&apos;intègre avec ces mécanismes via des authenticators
+                    personnalisés et la double authentification. Nous concevons des
+                    parcours de connexion qui élèvent le niveau de sécurité sans
+                    dégrader l&apos;expérience utilisateur. Sécuriser l&apos;accès
+                    n&apos;est qu&apos;un volet : un{" "}
+                    <Link
+                      href="/audit-code-php"
+                      className="text-primary hover:underline"
+                    >
+                      audit de code PHP
+                    </Link>{" "}
+                    complet vérifie aussi la robustesse de la logique
+                    d&apos;autorisation derrière l&apos;authentification.
+                  </p>
+                </div>
+              </div>
+            </Container>
+          </section>
+        </FadeIn>
+
+        <FadeIn>
+          <section className="bg-light-gray py-16 md:py-24">
+            <Container>
               <SectionTitle>Questions fréquentes</SectionTitle>
               <div className="mx-auto max-w-2xl">
                 <Accordion items={faqItems} />


### PR DESCRIPTION
Closes #733

- /migration-symfony : 6 H2 (Rector, tests, perf, migrations 4/5/6 vers 7)
- /agence-symfony-paris : 4 H2 (API Platform, Docker, PostgreSQL, stack)
- /expertise-ia : 4 H2 (RAG, LLM, agents, MCP)
- /securite-application-symfony : 4 H2 (OWASP, CVE, RGPD, WebAuthn)
- Chaque section : ancrage interne descriptif, 100-200 mots