### PR TITLE
feat: outil interactif evaluation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "gray-matter": "^4.0.3",
+        "jspdf": "^4.2.1",
         "next": "^16.2.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -522,7 +523,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4074,6 +4074,19 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -4106,6 +4119,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5353,6 +5373,16 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -5614,6 +5644,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -6070,6 +6120,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -6110,6 +6172,16 @@
       "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -6476,6 +6548,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -7619,6 +7701,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7658,6 +7751,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -8390,6 +8489,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8788,6 +8901,12 @@
         "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -10754,6 +10873,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -13230,6 +13366,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13393,6 +13535,13 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13773,6 +13922,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13903,6 +14062,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -14125,6 +14291,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -14808,6 +14984,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -15217,6 +15403,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15343,6 +15539,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/third-party-web": {
@@ -16092,6 +16298,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "gray-matter": "^4.0.3",
+    "jspdf": "^4.2.1",
     "next": "^16.2.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/outil-evaluation-nis2-symfony/page.tsx
+++ b/src/app/outil-evaluation-nis2-symfony/page.tsx
@@ -10,6 +10,7 @@ import type { RelatedLink } from "@/components/sections/RelatedLinks";
 import CallToAction from "@/components/sections/CallToAction";
 import Nis2Assessment from "@/components/sections/Nis2Assessment";
 import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
+import { BASE_URL } from "@/lib/metadata";
 
 export const metadata = pageMetadata({
   title: "Évaluation NIS2 Symfony - outil gratuit",
@@ -83,16 +84,16 @@ const webPage = webPageJsonLd({
 
 const webApplication = {
   "@type": "WebApplication",
-  "@id": "https://www.itefficience.com/outil-evaluation-nis2-symfony#app",
+  "@id": `${BASE_URL}/outil-evaluation-nis2-symfony#app`,
   name: "Évaluation NIS2 Symfony",
   description:
     "Outil d'auto-évaluation technique de la conformité NIS2 pour une application Symfony. 15 questions, score sur 100 et rapport téléchargeable, calcul 100% côté navigateur.",
-  url: "https://www.itefficience.com/outil-evaluation-nis2-symfony",
+  url: `${BASE_URL}/outil-evaluation-nis2-symfony`,
   applicationCategory: "SecurityApplication",
   operatingSystem: "Web",
   inLanguage: "fr-FR",
   isAccessibleForFree: true,
-  provider: { "@id": "https://www.itefficience.com/#organization" },
+  provider: { "@id": `${BASE_URL}/#organization` },
 };
 
 export default function OutilEvaluationNis2Symfony() {

--- a/src/app/outil-evaluation-nis2-symfony/page.tsx
+++ b/src/app/outil-evaluation-nis2-symfony/page.tsx
@@ -1,0 +1,218 @@
+import Link from "next/link";
+import { pageMetadata } from "@/lib/metadata";
+import Container from "@/components/ui/Container";
+import SectionTitle from "@/components/ui/SectionTitle";
+import Card from "@/components/ui/Card";
+import FadeIn from "@/components/ui/FadeIn";
+import Breadcrumb from "@/components/ui/Breadcrumb";
+import RelatedLinks from "@/components/sections/RelatedLinks";
+import type { RelatedLink } from "@/components/sections/RelatedLinks";
+import CallToAction from "@/components/sections/CallToAction";
+import Nis2Assessment from "@/components/sections/Nis2Assessment";
+import { breadcrumbJsonLd, webPageJsonLd, pageGraphJsonLd } from "@/lib/structured-data";
+
+export const metadata = pageMetadata({
+  title: "Évaluation NIS2 Symfony - outil gratuit",
+  description:
+    "Évaluez la conformité technique de votre application Symfony aux exigences NIS2 en 5 minutes.",
+  path: "/outil-evaluation-nis2-symfony",
+});
+
+const axes = [
+  {
+    title: "Socle technique et durcissement",
+    description:
+      "Versions de PHP et Symfony supportées, mode debug désactivé en production, headers de sécurité HTTP.",
+  },
+  {
+    title: "Authentification et contrôle d'accès",
+    description:
+      "MFA sur les comptes à privilèges, authentification forte, principe de moindre privilège.",
+  },
+  {
+    title: "Secrets et données sensibles",
+    description:
+      "Gestion des secrets hors du code, chiffrement des données, anonymisation des environnements de test.",
+  },
+  {
+    title: "Journalisation et détection",
+    description:
+      "Journaux de sécurité structurés et capacité à qualifier un incident dans les délais NIS2.",
+  },
+  {
+    title: "Dépendances et continuité",
+    description:
+      "Scan automatisé des dépendances, pipeline CI/CD outillé et plan de réponse à incident documenté.",
+  },
+];
+
+const relatedLinks: RelatedLink[] = [
+  {
+    title: "Sécurité applicative Symfony",
+    description: "Audit, hardening et conformité de vos applications",
+    href: "/securite-application-symfony",
+  },
+  {
+    title: "Conformité NIS2 : guide technique",
+    description: "Préparer votre application Symfony aux exigences NIS2",
+    href: "/article/conformite-nis2-application-symfony",
+  },
+  {
+    title: "Audit de code PHP",
+    description: "Diagnostic complet de votre code PHP sous 48h",
+    href: "/audit-code-php",
+  },
+  {
+    title: "Audit Symfony gratuit",
+    description: "30 minutes pour évaluer l'état de votre application",
+    href: "/audit-symfony-gratuit",
+  },
+];
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: "Sécurité applicative Symfony", path: "/securite-application-symfony" },
+  { name: "Évaluation NIS2 Symfony", path: "/outil-evaluation-nis2-symfony" },
+]);
+
+const webPage = webPageJsonLd({
+  name: "Évaluation NIS2 Symfony - outil gratuit",
+  description:
+    "Évaluez la conformité technique de votre application Symfony aux exigences NIS2 en 5 minutes.",
+  path: "/outil-evaluation-nis2-symfony",
+});
+
+const webApplication = {
+  "@type": "WebApplication",
+  "@id": "https://www.itefficience.com/outil-evaluation-nis2-symfony#app",
+  name: "Évaluation NIS2 Symfony",
+  description:
+    "Outil d'auto-évaluation technique de la conformité NIS2 pour une application Symfony. 15 questions, score sur 100 et rapport téléchargeable, calcul 100% côté navigateur.",
+  url: "https://www.itefficience.com/outil-evaluation-nis2-symfony",
+  applicationCategory: "SecurityApplication",
+  operatingSystem: "Web",
+  inLanguage: "fr-FR",
+  isAccessibleForFree: true,
+  provider: { "@id": "https://www.itefficience.com/#organization" },
+};
+
+export default function OutilEvaluationNis2Symfony() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            pageGraphJsonLd(breadcrumb, webPage, webApplication),
+          ),
+        }}
+      />
+      <main>
+        <section className="bg-light-gray py-16 md:py-24">
+          <Container>
+            <Breadcrumb items={[{ label: "Évaluation NIS2 Symfony" }]} />
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="text-sm font-semibold uppercase tracking-wider text-primary">
+                Outil gratuit
+              </p>
+              <h1 className="mt-2 font-display text-4xl font-bold text-dark md:text-5xl">
+                Évaluation NIS2 pour votre application Symfony
+              </h1>
+              <p className="mt-6 text-lg text-gray">
+                En 15 questions et environ 5 minutes, situez la maturité de votre
+                application Symfony face aux exigences techniques de la directive
+                NIS2. Score sur 100, détail par axe et rapport téléchargeable. Le
+                calcul est entièrement réalisé dans votre navigateur : aucune
+                donnée n&apos;est transmise.
+              </p>
+            </div>
+          </Container>
+        </section>
+
+        <FadeIn>
+          <section className="py-16 md:py-24">
+            <Container>
+              <div className="mx-auto max-w-3xl">
+                <Nis2Assessment />
+              </div>
+            </Container>
+          </section>
+        </FadeIn>
+
+        <FadeIn>
+          <section className="bg-light-gray py-16 md:py-24">
+            <Container>
+              <SectionTitle>Les axes évalués</SectionTitle>
+              <p className="mx-auto mt-4 max-w-3xl text-center text-lg text-gray">
+                L&apos;outil couvre les cinq familles de mesures techniques les
+                plus structurantes pour préparer une application Symfony à NIS2.
+              </p>
+              <div className="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {axes.map((axis) => (
+                  <Card key={axis.title}>
+                    <h2 className="font-display text-lg font-bold text-dark">
+                      {axis.title}
+                    </h2>
+                    <p className="mt-2 text-gray">{axis.description}</p>
+                  </Card>
+                ))}
+              </div>
+            </Container>
+          </section>
+        </FadeIn>
+
+        <FadeIn>
+          <section className="py-16 md:py-24">
+            <Container>
+              <div className="mx-auto max-w-3xl space-y-4 text-lg text-gray">
+                <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
+                  Une indication, pas un audit officiel
+                </h2>
+                <p>
+                  Ce questionnaire fournit un état des lieux rapide et
+                  pédagogique. Il ne remplace pas un audit réglementaire : la
+                  qualification d&apos;un prestataire d&apos;audit relève en
+                  France du dispositif PASSI piloté par l&apos;ANSSI. Pour
+                  comprendre en détail ce que recouvre la directive, consultez
+                  notre guide pour{" "}
+                  <Link
+                    href="/article/conformite-nis2-application-symfony"
+                    className="text-primary hover:underline"
+                  >
+                    préparer techniquement votre application à NIS2
+                  </Link>
+                  .
+                </p>
+                <p>
+                  Une fois votre score obtenu, nous pouvons transformer ces
+                  signaux en plan d&apos;action concret grâce à notre{" "}
+                  <Link
+                    href="/securite-application-symfony"
+                    className="text-primary hover:underline"
+                  >
+                    expertise en sécurité applicative Symfony
+                  </Link>{" "}
+                  et à un{" "}
+                  <Link
+                    href="/audit-code-php"
+                    className="text-primary hover:underline"
+                  >
+                    audit de code PHP
+                  </Link>{" "}
+                  approfondi.
+                </p>
+              </div>
+            </Container>
+          </section>
+        </FadeIn>
+
+        <FadeIn>
+          <RelatedLinks links={relatedLinks} className="bg-light-gray" />
+        </FadeIn>
+
+        <FadeIn>
+          <CallToAction />
+        </FadeIn>
+      </main>
+    </>
+  );
+}

--- a/src/components/sections/Nis2Assessment.tsx
+++ b/src/components/sections/Nis2Assessment.tsx
@@ -1,0 +1,578 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import { trackEvent } from "@/lib/tracking";
+
+type Axis = {
+  id: string;
+  title: string;
+  advice: string;
+  href: string;
+  hrefLabel: string;
+};
+
+type Question = {
+  id: string;
+  axisId: string;
+  text: string;
+  options: { label: string; value: number }[];
+};
+
+const AXES: Axis[] = [
+  {
+    id: "socle",
+    title: "Socle technique et durcissement",
+    advice:
+      "Mettez à jour PHP et Symfony vers des versions supportées, désactivez le debug en production et ajoutez les headers de sécurité.",
+    href: "/securite-application-symfony",
+    hrefLabel: "Sécurité applicative Symfony",
+  },
+  {
+    id: "auth",
+    title: "Authentification et contrôle d'accès",
+    advice:
+      "Généralisez le MFA sur les comptes à privilèges et appliquez le principe de moindre privilège à chaque rôle.",
+    href: "/article/conformite-nis2-application-symfony",
+    hrefLabel: "Préparer son application à NIS2",
+  },
+  {
+    id: "secrets",
+    title: "Secrets et données sensibles",
+    advice:
+      "Sortez les secrets du code, chiffrez les données sensibles et anonymisez vos environnements de test.",
+    href: "/article/dbtoolsbundle-anonymiser-vos-bases-de-donnees",
+    hrefLabel: "Anonymiser ses bases de données",
+  },
+  {
+    id: "logs",
+    title: "Journalisation et détection",
+    advice:
+      "Structurez la journalisation des événements de sécurité et centralisez-la pour pouvoir qualifier un incident rapidement.",
+    href: "/article/conformite-nis2-application-symfony",
+    hrefLabel: "La notification d'incident NIS2",
+  },
+  {
+    id: "chaine",
+    title: "Dépendances et continuité",
+    advice:
+      "Automatisez le scan des dépendances dans la CI et documentez un plan de réponse à incident testé.",
+    href: "/article/cve-comprendre-les-failles-pour-mieux-se-proteger",
+    hrefLabel: "Comprendre et gérer les CVE",
+  },
+];
+
+const QUESTIONS: Question[] = [
+  {
+    id: "php",
+    axisId: "socle",
+    text: "Quelle version de PHP fait tourner votre application en production ?",
+    options: [
+      { label: "PHP 8.3 ou plus récent", value: 1 },
+      { label: "PHP 8.1 ou 8.2", value: 0.6 },
+      { label: "PHP 8.0 ou antérieur", value: 0 },
+      { label: "Je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "symfony",
+    axisId: "socle",
+    text: "Quelle version de Symfony utilisez-vous ?",
+    options: [
+      { label: "Symfony 7.x", value: 1 },
+      { label: "Symfony 6.4 LTS", value: 0.8 },
+      { label: "Symfony 5.x ou antérieur", value: 0 },
+      { label: "Je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "headers",
+    axisId: "socle",
+    text: "Les headers de sécurité (CSP, HSTS, X-Content-Type-Options) sont-ils configurés ?",
+    options: [
+      { label: "Oui, configurés et vérifiés", value: 1 },
+      { label: "Partiellement", value: 0.5 },
+      { label: "Non ou je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "debug",
+    axisId: "socle",
+    text: "Le mode debug est-il désactivé en production avec une gestion propre des erreurs ?",
+    options: [
+      { label: "Oui, strictement", value: 1 },
+      { label: "Partiellement", value: 0.5 },
+      { label: "Non ou je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "mfa-admin",
+    axisId: "auth",
+    text: "Le MFA est-il activé pour les comptes d'administration ?",
+    options: [
+      { label: "Oui, pour tous les comptes à privilèges", value: 1 },
+      { label: "Pour certains comptes seulement", value: 0.5 },
+      { label: "Non", value: 0 },
+    ],
+  },
+  {
+    id: "auth-forte",
+    axisId: "auth",
+    text: "Proposez-vous une authentification forte (2FA, passkeys WebAuthn) aux utilisateurs sensibles ?",
+    options: [
+      { label: "Oui, en place", value: 1 },
+      { label: "En projet", value: 0.5 },
+      { label: "Non", value: 0 },
+    ],
+  },
+  {
+    id: "moindre-privilege",
+    axisId: "auth",
+    text: "Le contrôle d'accès suit-il le principe de moindre privilège (rôles, voters) ?",
+    options: [
+      { label: "Oui, formalisé et testé", value: 1 },
+      { label: "Informel", value: 0.5 },
+      { label: "Non ou je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "secrets",
+    axisId: "secrets",
+    text: "Comment gérez-vous les secrets (clés API, mots de passe) ?",
+    options: [
+      { label: "Coffre dédié ou Symfony Secrets", value: 1 },
+      { label: "Variables d'environnement", value: 0.6 },
+      { label: "En dur dans le code ou versionnés dans Git", value: 0 },
+    ],
+  },
+  {
+    id: "chiffrement",
+    axisId: "secrets",
+    text: "Les données personnelles sensibles sont-elles chiffrées au repos ?",
+    options: [
+      { label: "Oui", value: 1 },
+      { label: "Partiellement", value: 0.5 },
+      { label: "Non ou je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "anonymisation",
+    axisId: "secrets",
+    text: "Vos environnements de test utilisent-ils des données anonymisées ?",
+    options: [
+      { label: "Oui, systématiquement", value: 1 },
+      { label: "Parfois", value: 0.5 },
+      { label: "Non, données de production en clair", value: 0 },
+    ],
+  },
+  {
+    id: "logs",
+    axisId: "logs",
+    text: "Les événements de sécurité sont-ils journalisés de façon structurée ?",
+    options: [
+      { label: "Oui, centralisés et exploitables", value: 1 },
+      { label: "Journaux locaux non centralisés", value: 0.5 },
+      { label: "Non ou je ne sais pas", value: 0 },
+    ],
+  },
+  {
+    id: "detection",
+    axisId: "logs",
+    text: "Pouvez-vous détecter et qualifier un incident dans les délais NIS2 (24 à 72 h) ?",
+    options: [
+      { label: "Oui, outillé avec alertes", value: 1 },
+      { label: "Détection manuelle et lente", value: 0.5 },
+      { label: "Non", value: 0 },
+    ],
+  },
+  {
+    id: "scan-deps",
+    axisId: "chaine",
+    text: "Les dépendances sont-elles scannées automatiquement (composer audit) ?",
+    options: [
+      { label: "Oui, à chaque build en CI", value: 1 },
+      { label: "Ponctuellement", value: 0.5 },
+      { label: "Jamais", value: 0 },
+    ],
+  },
+  {
+    id: "cicd",
+    axisId: "chaine",
+    text: "Disposez-vous d'un pipeline CI/CD avec tests et contrôles qualité ?",
+    options: [
+      { label: "Oui, complet (tests, analyse statique)", value: 1 },
+      { label: "Partiel", value: 0.5 },
+      { label: "Aucun", value: 0 },
+    ],
+  },
+  {
+    id: "plan-incident",
+    axisId: "chaine",
+    text: "Avez-vous un plan de réponse à incident documenté ?",
+    options: [
+      { label: "Oui, documenté et testé", value: 1 },
+      { label: "Documenté mais jamais testé", value: 0.5 },
+      { label: "Aucun", value: 0 },
+    ],
+  },
+];
+
+const CONTACT_EMAIL = "contact@itefficience.com";
+
+function levelOf(pct: number): "vert" | "orange" | "rouge" {
+  if (pct >= 70) return "vert";
+  if (pct >= 40) return "orange";
+  return "rouge";
+}
+
+const LEVEL_LABEL: Record<string, string> = {
+  vert: "Bonne maturité",
+  orange: "À renforcer",
+  rouge: "Point de vigilance",
+};
+
+const BAR_COLOR: Record<string, string> = {
+  vert: "bg-green-500",
+  orange: "bg-amber-500",
+  rouge: "bg-red-500",
+};
+
+const TEXT_COLOR: Record<string, string> = {
+  vert: "text-green-700",
+  orange: "text-amber-700",
+  rouge: "text-red-700",
+};
+
+export default function Nis2Assessment() {
+  const [started, setStarted] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, number>>({});
+  const [finished, setFinished] = useState(false);
+  const [leadSent, setLeadSent] = useState(false);
+
+  const result = useMemo(() => {
+    const perAxis = AXES.map((axis) => {
+      const axisQuestions = QUESTIONS.filter((q) => q.axisId === axis.id);
+      const answered = axisQuestions.filter((q) => answers[q.id] !== undefined);
+      const sum = axisQuestions.reduce(
+        (acc, q) => acc + (answers[q.id] ?? 0),
+        0,
+      );
+      const pct =
+        axisQuestions.length > 0
+          ? Math.round((sum / axisQuestions.length) * 100)
+          : 0;
+      return { axis, pct, level: levelOf(pct), answered: answered.length };
+    });
+    const globalSum = QUESTIONS.reduce(
+      (acc, q) => acc + (answers[q.id] ?? 0),
+      0,
+    );
+    const global = Math.round((globalSum / QUESTIONS.length) * 100);
+    return { perAxis, global, level: levelOf(global) };
+  }, [answers]);
+
+  const answer = (value: number) => {
+    const q = QUESTIONS[current];
+    const next = { ...answers, [q.id]: value };
+    setAnswers(next);
+    if (current + 1 < QUESTIONS.length) {
+      setCurrent(current + 1);
+    } else {
+      setFinished(true);
+      const score = Math.round(
+        (Object.values(next).reduce((a, b) => a + b, 0) / QUESTIONS.length) *
+          100,
+      );
+      trackEvent("nis2_assessment_completed", {
+        event_label: String(score),
+        source_page:
+          typeof window !== "undefined" ? window.location.pathname : "",
+      });
+    }
+  };
+
+  const back = () => {
+    if (current > 0) setCurrent(current - 1);
+  };
+
+  const restart = () => {
+    setAnswers({});
+    setCurrent(0);
+    setFinished(false);
+    setStarted(true);
+    setLeadSent(false);
+  };
+
+  const downloadPdf = async () => {
+    const { jsPDF } = await import("jspdf");
+    const doc = new jsPDF({ unit: "pt", format: "a4" });
+    const marginX = 48;
+    let y = 64;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(20);
+    doc.text("Évaluation NIS2 Symfony", marginX, y);
+    y += 26;
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+    doc.setTextColor(110);
+    doc.text("Auto-évaluation technique - Efficience IT", marginX, y);
+    y += 34;
+    doc.setTextColor(20);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(15);
+    doc.text(
+      `Score global de maturité : ${result.global}/100 (${LEVEL_LABEL[result.level]})`,
+      marginX,
+      y,
+    );
+    y += 30;
+    doc.setFontSize(13);
+    doc.text("Détail par axe", marginX, y);
+    y += 8;
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+    result.perAxis.forEach((row) => {
+      y += 22;
+      doc.text(
+        `${row.axis.title} : ${row.pct}/100 (${LEVEL_LABEL[row.level]})`,
+        marginX,
+        y,
+      );
+    });
+    y += 40;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(13);
+    doc.text("Recommandations prioritaires", marginX, y);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+    const priorities = result.perAxis.filter((r) => r.level !== "vert");
+    const list = priorities.length > 0 ? priorities : result.perAxis;
+    list.forEach((row) => {
+      const lines = doc.splitTextToSize(
+        `- ${row.axis.title} : ${row.axis.advice}`,
+        500,
+      );
+      y += 20;
+      doc.text(lines, marginX, y);
+      y += (lines.length - 1) * 14;
+    });
+    y += 40;
+    doc.setTextColor(110);
+    doc.setFontSize(10);
+    doc.text(
+      "Ce rapport est une auto-évaluation indicative et ne constitue pas un audit officiel.",
+      marginX,
+      y,
+    );
+    y += 14;
+    doc.text(
+      "Une attestation NIS2 relève d'un auditeur PASSI. Contact : contact@itefficience.com",
+      marginX,
+      y,
+    );
+    doc.save("evaluation-nis2-symfony.pdf");
+    trackEvent("nis2_assessment_pdf", {
+      event_label: String(result.global),
+      source_page:
+        typeof window !== "undefined" ? window.location.pathname : "",
+    });
+  };
+
+  const sendLead = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const email = data.get("email");
+    const company = data.get("company") || "";
+    const subject = "Évaluation NIS2 Symfony - demande d'accompagnement";
+    const body = [
+      `Email : ${email}`,
+      `Entreprise : ${company}`,
+      "",
+      `Score global : ${result.global}/100 (${LEVEL_LABEL[result.level]})`,
+      "",
+      "Détail par axe :",
+      ...result.perAxis.map(
+        (r) => `- ${r.axis.title} : ${r.pct}/100 (${LEVEL_LABEL[r.level]})`,
+      ),
+    ].join("\n");
+    trackEvent("nis2_assessment_lead", {
+      event_label: String(result.global),
+      source_page:
+        typeof window !== "undefined" ? window.location.pathname : "",
+    });
+    window.open(
+      `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`,
+      "_blank",
+    );
+    setLeadSent(true);
+  };
+
+  if (!started) {
+    return (
+      <div className="rounded-2xl border border-border bg-white p-8 text-center shadow-sm dark:bg-light-gray">
+        <p className="text-lg text-gray">
+          15 questions, environ 5 minutes. Tout est calculé dans votre
+          navigateur : aucune donnée n&apos;est envoyée tant que vous ne le
+          demandez pas.
+        </p>
+        <div className="mt-6">
+          <Button onClick={() => setStarted(true)}>Commencer l&apos;évaluation</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!finished) {
+    const q = QUESTIONS[current];
+    const axis = AXES.find((a) => a.id === q.axisId);
+    const progress = Math.round((current / QUESTIONS.length) * 100);
+    return (
+      <div className="rounded-2xl border border-border bg-white p-8 shadow-sm dark:bg-light-gray">
+        <div className="mb-6">
+          <div className="flex items-center justify-between text-sm text-gray">
+            <span>{axis?.title}</span>
+            <span>
+              Question {current + 1} / {QUESTIONS.length}
+            </span>
+          </div>
+          <div className="mt-2 h-2 w-full rounded-full bg-light-gray dark:bg-white/20">
+            <div
+              className="h-2 rounded-full bg-primary transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+        <h2 className="font-display text-xl font-bold text-dark md:text-2xl">
+          {q.text}
+        </h2>
+        <div className="mt-6 space-y-3">
+          {q.options.map((opt) => (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => answer(opt.value)}
+              className="block w-full rounded-lg border border-border bg-white px-5 py-3 text-left text-dark transition hover:border-primary hover:bg-primary/5 dark:bg-white/5"
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        {current > 0 && (
+          <button
+            type="button"
+            onClick={back}
+            className="mt-6 text-sm font-medium text-gray hover:text-primary"
+          >
+            Question précédente
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-border bg-white p-8 shadow-sm dark:bg-light-gray">
+      <p className="text-sm font-semibold uppercase tracking-wider text-gray">
+        Votre score de maturité NIS2
+      </p>
+      <div className="mt-2 flex items-baseline gap-3">
+        <span className="font-display text-5xl font-bold text-dark">
+          {result.global}
+        </span>
+        <span className="text-xl text-gray">/ 100</span>
+        <span className={`text-lg font-semibold ${TEXT_COLOR[result.level]}`}>
+          {LEVEL_LABEL[result.level]}
+        </span>
+      </div>
+
+      <div className="mt-8 space-y-5">
+        {result.perAxis.map((row) => (
+          <div key={row.axis.id}>
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-dark">{row.axis.title}</span>
+              <span className={`font-semibold ${TEXT_COLOR[row.level]}`}>
+                {row.pct}/100
+              </span>
+            </div>
+            <div className="mt-1 h-2 w-full rounded-full bg-light-gray dark:bg-white/20">
+              <div
+                className={`h-2 rounded-full ${BAR_COLOR[row.level]}`}
+                style={{ width: `${row.pct}%` }}
+              />
+            </div>
+            {row.level !== "vert" && (
+              <p className="mt-2 text-sm text-gray">
+                {row.axis.advice}{" "}
+                <Link
+                  href={row.axis.href}
+                  className="text-primary hover:underline"
+                >
+                  {row.axis.hrefLabel}
+                </Link>
+                .
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        <Button onClick={downloadPdf}>Télécharger le rapport PDF</Button>
+        <button
+          type="button"
+          onClick={restart}
+          className="rounded-lg border border-border px-6 py-3 font-semibold text-dark transition hover:border-primary"
+        >
+          Recommencer
+        </button>
+      </div>
+
+      <div className="mt-8 rounded-xl bg-light-gray p-6 dark:bg-white/5">
+        <p className="text-sm text-gray">
+          Cette évaluation est indicative et ne remplace pas un audit officiel.
+          Une attestation NIS2 relève d&apos;un auditeur PASSI. Pour un état des
+          lieux approfondi, appuyez-vous sur notre{" "}
+          <Link
+            href="/securite-application-symfony"
+            className="text-primary hover:underline"
+          >
+            expertise en sécurité applicative Symfony
+          </Link>{" "}
+          ou notre{" "}
+          <Link href="/audit-code-php" className="text-primary hover:underline">
+            audit de code PHP
+          </Link>
+          .
+        </p>
+
+        {leadSent ? (
+          <p className="mt-4 font-semibold text-green-700">
+            Merci ! Votre client mail va s&apos;ouvrir pour finaliser l&apos;envoi.
+          </p>
+        ) : (
+          <form
+            onSubmit={sendLead}
+            className="mt-4 grid gap-3 sm:grid-cols-[1fr_1fr_auto]"
+          >
+            <input
+              type="email"
+              name="email"
+              required
+              placeholder="Votre email professionnel"
+              className="rounded-md border border-border bg-white px-4 py-2 text-dark focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            <input
+              type="text"
+              name="company"
+              placeholder="Entreprise (optionnel)"
+              className="rounded-md border border-border bg-white px-4 py-2 text-dark focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            <Button type="submit">Être accompagné</Button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -69,6 +69,7 @@ export const STATIC_SILOS: RouteSilo[] = [
       { path: "/hebergement-symfony", label: "Hébergement Symfony", lastModified: "2026-03-13", changeFrequency: "monthly", priority: 0.8 },
       { path: "/integration-docker-symfony", label: "Intégration Docker Symfony", lastModified: "2026-03-17", changeFrequency: "monthly", priority: 0.8 },
       { path: "/securite-application-symfony", label: "Sécurité d'application Symfony", lastModified: "2026-03-17", changeFrequency: "monthly", priority: 0.8 },
+      { path: "/outil-evaluation-nis2-symfony", label: "Évaluation NIS2 Symfony", lastModified: "2026-06-02", changeFrequency: "monthly", priority: 0.8 },
       { path: "/base-de-donnees-postgresql-symfony", label: "Base de données PostgreSQL avec Symfony", lastModified: "2026-03-17", changeFrequency: "monthly", priority: 0.8 },
       { path: "/integration-redis-symfony", label: "Intégration Redis Symfony", lastModified: "2026-03-17", changeFrequency: "monthly", priority: 0.8 },
       { path: "/integration-elasticsearch-symfony", label: "Intégration Elasticsearch Symfony", lastModified: "2026-03-17", changeFrequency: "monthly", priority: 0.8 },


### PR DESCRIPTION
Closes #724

Stacked sur #746 (l'outil maille vers l'article NIS2 créé dans cette PR). À merger après #746 ; GitHub re-ciblera la base sur main automatiquement.

- Page /outil-evaluation-nis2-symfony (indexable, schema WebApplication, breadcrumb)
- Composant client : 15 questions, score /100, 5 axes (rouge/orange/vert)
- Rapport PDF téléchargeable (jsPDF), calcul 100% navigateur
- Capture email optionnelle via mailto (récap score)
- Maillage : /securite-application-symfony, /audit-code-php, /audit-symfony-gratuit, article NIS2
- Ajout au sitemap (routes.ts)