### PR TITLE
content: H1 pages stratégiques

### DIFF
--- a/src/__tests__/pages.test.tsx
+++ b/src/__tests__/pages.test.tsx
@@ -44,7 +44,7 @@ describe("Company pages", () => {
 
   it("renders La team", () => {
     render(<LaTeam />);
-    expect(screen.getByRole("heading", { name: /une équipe passionnée/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /une équipe symfony passionnée/i })).toBeInTheDocument();
   });
 
   it("renders Ta carrière", () => {
@@ -71,7 +71,7 @@ describe("Blog & other pages", () => {
 
   it("renders Contact", () => {
     render(<Contact />);
-    expect(screen.getByRole("heading", { name: /contactez-nous/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /contactez efficience it/i })).toBeInTheDocument();
   });
 
   it("renders Mentions légales", () => {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -52,7 +52,7 @@ export default function Contact() {
             <Breadcrumb items={[{ label: "Contact" }]} />
             <LastUpdated path="/contact" />
             <h1 className="font-display text-4xl font-bold text-dark md:text-5xl">
-              Contactez-nous
+              Contactez Efficience IT : parlons de votre projet Symfony
             </h1>
             <p className="mx-auto mt-6 max-w-3xl text-lg text-gray">
               Vous avez un projet ? Une question ? N&apos;hésitez pas à nous

--- a/src/app/green-it/page.tsx
+++ b/src/app/green-it/page.tsx
@@ -78,7 +78,7 @@ export default function GreenIt() {
                 Notre engagement RSE
               </p>
               <h1 className="mt-2 font-display text-4xl font-bold text-dark md:text-5xl">
-                Green IT
+                Green IT : développement web éco-responsable
               </h1>
               <p className="mt-6 text-lg text-gray">
                 Efficience IT est engagée dans une démarche RSE, en particulier

--- a/src/app/l-entreprise/page.tsx
+++ b/src/app/l-entreprise/page.tsx
@@ -149,7 +149,7 @@ export default function LEntreprise() {
           <div className="grid items-center gap-12 md:grid-cols-2">
             <div>
               <h1 className="font-display text-4xl font-bold text-dark md:text-5xl">
-                Notre histoire
+                Notre histoire : agence Symfony depuis 2018
               </h1>
               <h2 className="font-display text-2xl font-bold text-dark md:text-3xl">
                 Experts en Symfony et en développement web

--- a/src/app/la-team/page.tsx
+++ b/src/app/la-team/page.tsx
@@ -66,7 +66,7 @@ export default function LaTeam() {
                 La team
               </p>
               <h1 className="mt-2 font-display text-4xl font-bold text-dark md:text-5xl">
-                Une équipe passionnée
+                Une équipe Symfony passionnée
               </h1>
               <p className="mt-6 max-w-3xl text-lg text-gray">
                 À taille humaine, notre équipe est à fond dans le digital et


### PR DESCRIPTION
Étoffe les H1 trop courts (<3 mots, sans mot-clé) :
- /contact : Contactez-nous → Contactez Efficience IT : parlons de votre projet Symfony
- /green-it : Green IT → Green IT : développement web éco-responsable
- /l-entreprise : Notre histoire → Notre histoire : agence Symfony depuis 2018
- /la-team : Une équipe passionnée → Une équipe Symfony passionnée

Tests pages mis à jour. /ta-carriere et /nos-references déjà conformes, /mentions-legales laissé (page légale).

closes #662