### PR TITLE
ci: garde-fou dates sitemap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript-typescript
@@ -30,6 +32,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - name: Dates du sitemap
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: npm run check:route-dates
       - run: npm ci --prefer-offline --no-audit --no-fund
       - run: npm run lint
       - run: npx tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "knip": "knip",
     "test": "jest",
     "generate:image-variants": "npx -y tsx@4 scripts/generate-image-variants.ts",
-    "audit:anchor-diversity": "npx -y tsx@4 scripts/audit-anchor-diversity.ts --all"
+    "audit:anchor-diversity": "npx -y tsx@4 scripts/audit-anchor-diversity.ts --all",
+    "check:route-dates": "npx -y tsx@4 scripts/check-route-dates.ts"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/scripts/check-route-dates.ts
+++ b/scripts/check-route-dates.ts
@@ -1,0 +1,67 @@
+import { execSync } from "child_process";
+import fs from "fs";
+
+const ROUTES_FILE = "src/lib/routes.ts";
+
+function lastModifiedFor(routesSource: string, routePath: string): string | null {
+  const escaped = routePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`path:\\s*"${escaped}"[^}]*?lastModified:\\s*"([^"]+)"`);
+  const match = routesSource.match(re);
+  return match ? match[1] : null;
+}
+
+function pathFromPageFile(file: string): string | null {
+  const match = file.match(/^src\/app\/(.*)page\.tsx$/);
+  if (!match) return null;
+  const dir = match[1].replace(/\/$/, "");
+  if (dir === "") return "/";
+  if (dir.includes("[")) return null;
+  return `/${dir}`;
+}
+
+function main(): void {
+  const base = process.env.BASE_SHA;
+  if (!base) {
+    console.log("BASE_SHA non défini, vérification des dates ignorée.");
+    return;
+  }
+
+  const changed = execSync(`git diff --name-only ${base} HEAD`, { encoding: "utf-8" })
+    .split("\n")
+    .filter(Boolean);
+
+  const currentRoutes = fs.readFileSync(ROUTES_FILE, "utf-8");
+  let baseRoutes = "";
+  try {
+    baseRoutes = execSync(`git show ${base}:${ROUTES_FILE}`, { encoding: "utf-8" });
+  } catch {
+    baseRoutes = "";
+  }
+
+  const errors: string[] = [];
+  for (const file of changed) {
+    const routePath = pathFromPageFile(file);
+    if (!routePath) continue;
+    const current = lastModifiedFor(currentRoutes, routePath);
+    if (!current) continue;
+    const before = lastModifiedFor(baseRoutes, routePath);
+    if (before === null) continue;
+    if (before === current) {
+      errors.push(
+        `${file} a été modifié mais le lastModified de ${routePath} (${current}) n'a pas été mis à jour dans ${ROUTES_FILE}.`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      `Dates de sitemap périmées :\n${errors.map((e) => `  - ${e}`).join("\n")}\n` +
+        `Mettez à jour le lastModified de ces routes dans ${ROUTES_FILE}.`,
+    );
+    process.exit(1);
+  }
+
+  console.log("lastModified à jour pour les pages statiques modifiées.");
+}
+
+main();

--- a/src/__tests__/lib/routes.test.ts
+++ b/src/__tests__/lib/routes.test.ts
@@ -27,6 +27,13 @@ describe("getStaticRoutes", () => {
   it("includes the home route", () => {
     expect(getStaticRoutes().some((r) => r.path === "/")).toBe(true);
   });
+
+  it("exposes a valid ISO lastModified date for every route", () => {
+    for (const route of getStaticRoutes()) {
+      expect(route.lastModified).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isNaN(new Date(route.lastModified).getTime())).toBe(false);
+    }
+  });
 });
 
 describe("getCategoryRoutes", () => {


### PR DESCRIPTION
Garde-fou CI : interdit de modifier une page statique sans bumper son `lastModified` dans `routes.ts`.

- `scripts/check-route-dates.ts` : compare le diff PR vs base ; si un `src/app/<path>/page.tsx` change mais que le `lastModified` de la route reste identique → échec avec message explicite.
- Étape `Dates du sitemap` dans le workflow Tests (pull_request only, fetch-depth:0).
- Test unitaire : chaque `lastModified` statique est une date ISO valide.
- Blog/catégorie : déjà dynamiques (inchangés).

closes #623