### PR TITLE
content: quick wins audit

### DIFF
--- a/content/blog/dora-fintech-resilience-technique-symfony.mdx
+++ b/content/blog/dora-fintech-resilience-technique-symfony.mdx
@@ -30,7 +30,7 @@ Le point clé pour une fintech en croissance : même si vous n'êtes pas vous-m�
 
 ## Ce que DORA exige concrètement
 
-DORA repose sur cinq piliers. Quatre ont un impact technique direct sur une application Symfony.
+[DORA](https://eur-lex.europa.eu/eli/reg/2022/2554/oj) repose sur cinq piliers. Quatre ont un impact technique direct sur une application Symfony.
 
 La **gestion des risques liés aux TIC** impose un cadre documenté : cartographie des actifs, des dépendances et des points de défaillance uniques. La **notification des incidents majeurs** exige de détecter, classifier et déclarer un incident dans des délais courts. Les **tests de résilience opérationnelle** vont du test de continuité classique jusqu'aux tests d'intrusion fondés sur la menace (TLPT, Threat-Led Penetration Testing) pour les entités les plus critiques. Enfin, la **gestion des risques liés aux prestataires tiers** impose une cartographie contractuelle et des stratégies de sortie documentées.
 
@@ -54,7 +54,7 @@ DORA exige de garantir l'intégrité des systèmes. Cela commence par la chaîne
 
 Un plan de continuité non testé n'est qu'une intention. DORA demande des tests réels. Au-delà des sauvegardes restaurées et des bascules documentées, le chaos engineering injecte des pannes contrôlées (perte d'un service, latence réseau, indisponibilité d'une base) pour vérifier le comportement réel du système en conditions dégradées. Une base solide de [tests automatisés](/tests-automatises-php) est le préalable indispensable avant d'introduire ces scénarios de panne.
 
-Pour les entités les plus critiques, DORA va plus loin avec les tests d'intrusion fondés sur la menace (TLPT). Contrairement à un pentest classique, un TLPT simule des scénarios d'attaque réalistes inspirés de la menace réelle pesant sur le secteur financier, sur les systèmes de production ou des environnements représentatifs. Préparer une application Symfony à ce type d'exercice suppose un durcissement sérieux en amont : segmentation des accès, gestion stricte des secrets, surveillance active. Mieux vaut découvrir ses faiblesses lors d'un exercice cadré que lors d'une attaque réelle.
+Pour les entités les plus critiques, DORA va plus loin avec les tests d'intrusion fondés sur la menace (TLPT). Contrairement à un pentest classique, un TLPT simule des scénarios d'attaque réalistes inspirés de la menace réelle pesant sur le secteur financier, sur les systèmes de production ou des environnements représentatifs. Préparer une application Symfony à ce type d'exercice suppose un durcissement sérieux en amont : segmentation des accès, [gestion stricte des secrets](https://symfony.com/doc/current/configuration/secrets.html), surveillance active. Mieux vaut découvrir ses faiblesses lors d'un exercice cadré que lors d'une attaque réelle.
 
 ### Réversibilité contractuelle et technique
 

--- a/content/blog/rgaa-remediation-technique-symfony.mdx
+++ b/content/blog/rgaa-remediation-technique-symfony.mdx
@@ -56,7 +56,7 @@ La liste détaillée des 30 points est disponible dans notre [check-list RGAA te
 
 ## Refactoring des templates : méthodologie
 
-Corriger l'accessibilité d'une application existante ne se fait pas au hasard. Nous procédons en trois temps. D'abord les fondations à fort ratio impact/effort : structure sémantique, navigation clavier, contrastes, alternatives textuelles. Ces corrections touchent souvent des templates Twig partagés (layout, header, footer) et profitent immédiatement à toutes les pages.
+Corriger l'accessibilité d'une application existante ne se fait pas au hasard. Nous procédons en trois temps. D'abord les fondations à fort ratio impact/effort : structure sémantique, navigation clavier, contrastes, alternatives textuelles. Ces corrections touchent souvent des [templates Twig](https://symfony.com/doc/current/templates.html) partagés (layout, header, footer) et profitent immédiatement à toutes les pages.
 
 Vient ensuite le traitement des composants interactifs, mutualisés autant que possible. Plutôt que de corriger dix formulaires un par un, nous corrigeons le composant de formulaire réutilisable. Enfin, les cas complexes : contenus riches, applications monopages, contenus générés par les utilisateurs. À chaque étape, les tests automatisés figent le comportement obtenu pour éviter toute régression lors des évolutions futures. Cette approche progressive et outillée est au cœur de notre [processus de collaboration](/processus-collaboration).
 
@@ -64,7 +64,7 @@ L'objectif final est d'encoder l'accessibilité dans le design system plutôt qu
 
 ## La déclaration d'accessibilité
 
-La conformité ne se limite pas au code : le RGAA impose la publication d'une déclaration d'accessibilité, mise à jour annuellement. Elle indique le taux de conformité, les contenus non accessibles, les dérogations éventuelles et un moyen de contact pour signaler un défaut. Nous aidons à produire ce document à partir des résultats de l'audit, et à mettre en place la page dédiée ainsi que le mécanisme de signalement. C'est une obligation souvent oubliée, alors qu'elle est l'un des premiers éléments vérifiés en cas de contrôle.
+La conformité ne se limite pas au code : le [RGAA](https://accessibilite.numerique.gouv.fr/) impose la publication d'une déclaration d'accessibilité, mise à jour annuellement. Elle indique le taux de conformité, les contenus non accessibles, les dérogations éventuelles et un moyen de contact pour signaler un défaut. Nous aidons à produire ce document à partir des résultats de l'audit, et à mettre en place la page dédiée ainsi que le mécanisme de signalement. C'est une obligation souvent oubliée, alors qu'elle est l'un des premiers éléments vérifiés en cas de contrôle.
 
 Techniquement, cette page est un livrable comme un autre : une route Symfony dédiée, un contenu structuré et accessible (elle se doit d'être exemplaire), et un schéma d'état qui reflète le taux de conformité réel. Nous recommandons de la générer à partir d'une source unique, afin qu'une nouvelle campagne d'audit mette à jour la déclaration sans réécriture manuelle. Le mécanisme de signalement, lui, doit aboutir à une boîte réellement surveillée : une déclaration qui pointe vers une adresse morte est un signal négatif autant qu'un risque juridique.
 

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -28,7 +28,7 @@ const defaultButtons: CallToActionButton[] = [
 
 export default function CallToAction({
   title = "Vous avez un projet en tête ?",
-  description = "Vous souhaitez réaliser un intranet, un progiciel, une application d&apos;entreprise ou un site internet complexe ? Efficience IT saura vous accompagner au mieux sur vos projets !",
+  description = "Vous souhaitez réaliser un intranet, un progiciel, une application d'entreprise ou un site internet complexe ? Efficience IT saura vous accompagner au mieux sur vos projets !",
   buttons = defaultButtons,
 }: Readonly<CallToActionProps>) {
   return (


### PR DESCRIPTION
Quick wins issus de l'audit SEO :
- Corrige le bug `d&apos;entreprise` rendu littéralement en homepage (`CallToAction.tsx`, string JS)
- Ajoute liens d'autorité aux 2 articles techniques qui n'en avaient aucun (conformité CLAUDE.md) :
  - rgaa-remediation : référentiel RGAA officiel + doc Twig Symfony
  - dora-fintech : règlement DORA (eur-lex) + doc Symfony Secrets