### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - run: npm ci --prefer-offline --no-audit --no-fund
       - run: npx -y tsx@4 scripts/ping-indexers.ts
         env:
           PREVIOUS_SHA: ${{ github.event.before }}


### PR DESCRIPTION
Le job Ping échoue: `gray-matter` introuvable car les dépendances ne sont pas installées avant `tsx scripts/ping-indexers.ts`.

- Ajout de `npm ci` avant le script